### PR TITLE
Add Midnight chain support

### DIFF
--- a/fakenet-signer/src/modules/MidnightMonitor.ts
+++ b/fakenet-signer/src/modules/MidnightMonitor.ts
@@ -1,0 +1,776 @@
+/**
+ * MidnightMonitor - Generic signet monitor for any Midnight contract.
+ *
+ * The MPC needs ONLY the signet contract address. Requester contracts are
+ * discovered through the signet registry, and each notification names the
+ * ledger field position of the caller's SignBidirectionalEventMap, so no
+ * compiled caller contract, ZK keys or contract-info.json are needed to
+ * READ state (posting responses uses the published signet contract package).
+ *
+ * Flow:
+ * 1. Polls the signet contract's notification registry via the Midnight
+ *    GraphQL indexer (SignetRequestFeed)
+ * 2. Resolves each notification to an authenticated SignBidirectionalEvent
+ *    read from the named caller's own ledger
+ * 3. Builds ABI calldata + RLP transaction off-chain
+ * 4. Posts the MPC's ECDSA signature to the signet contract (postSignatureResponse)
+ * 5. After the EVM tx confirms, ECDSA-signs the attestation digest of
+ *    (requestId, serializedOutput, outputLen) with the MPC RESPONSE key for
+ *    the requesting contract (root key + the request's SENDER address + the
+ *    fixed "midnight response key" path — the same sender-scoped derivation
+ *    the real MPC uses, sig-net/mpc respond_bidirectional.rs) and posts the
+ *    RespondBidirectionalEvent on-chain (postRespondBidirectional). The
+ *    signet contract stores it unverified; clients verify against the
+ *    response key they pinned via initialise after their deploy. The USER
+ *    polls and calls claimDeposit().
+ */
+
+import { Buffer } from 'buffer';
+import { ethers } from 'ethers';
+import type { ServerConfig } from '../types';
+
+import type { SigningRequest } from './midnight/signet-request-types';
+
+// The attestation-digest circuit comes from signet-midnight compiled — the
+// SAME circuit client contracts verify against in-circuit
+// (verifyRespondBidirectionalEvent). Signing its output with the derived
+// response key is what makes a response verify at claim time.
+import {
+  bytesToHex,
+  bigintToBytes32,
+  deriveMidnightResponseSecretKey,
+  formatSecp256k1PublicKey,
+  secp256k1PublicKeyOf,
+  signAttestationDigest,
+  SignetRequestFeed,
+  signatureToSignatureRespondedEvent,
+  signBidirectionalEventToUnsignedEVMTransaction,
+  pureCircuits as signetCircuits,
+  MPCDestination,
+  MPCSignatureAlgorithm,
+  SERIALIZED_OUTPUT_BYTES,
+  type ResolvedSignetRequest,
+  type RequestIdHex,
+  type SignBidirectionalEvent,
+  type SignatureRespondedEvent,
+  type RespondBidirectionalEvent,
+} from '@sig-net/midnight';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { PublicDataProvider } from '@midnight-ntwrk/midnight-js-types';
+import { setNetworkId } from '@midnight-ntwrk/midnight-js/network-id';
+import {
+  findDeployedContract,
+  type FoundContract,
+} from '@midnight-ntwrk/midnight-js/contracts';
+import type { WalletFacade } from '@midnightntwrk/wallet-sdk-facade';
+import {
+  SIGNET_CONTRACT_PRIVATE_STATE_ID,
+  createSignetContractPrivateState,
+  type Contract as SignetContract,
+  type SignetContractPrivateState,
+} from '@sig-net/midnight-contract';
+
+import {
+  deriveAccountKeys,
+  initialiseWalletFacade,
+  type AccountKeys,
+} from './midnight/wallet';
+import type { NetworkId } from './midnight/network-id';
+import type { MidnightNodeConfig } from './midnight/midnight-node-config';
+// The contract package is platform-agnostic; the provider composition (zk
+// asset source, state store, wallet adapter) is this server's own.
+import {
+  buildSignetContractProviders,
+  makeSignetContractCompiledContract,
+  packagedManagedPath,
+} from './midnight/signet-contract-providers';
+
+// ---- Types ----
+
+export interface MidnightSigningRequest extends SigningRequest {
+  /**
+   * The nested on-ledger event record as read by signet-midnight — the
+   * canonical source the shared tx builder consumes. The flat `SigningRequest`
+   * fields are the string-decoded/flattened view kept for key derivation,
+   * signing, and logging.
+   */
+  signetRequest: SignBidirectionalEvent;
+}
+
+export interface SignedResponse {
+  requestId: string;
+  serializedOutput: string;
+  outputLen: number;
+  /** ECDSA signature scalar r as hex (32 little-endian bytes, ledger form). */
+  r: string;
+  /** ECDSA signature scalar s as hex (32 little-endian bytes, ledger form). */
+  s: string;
+  /** Recovery id (parity of R.y). */
+  recoveryId: number;
+}
+
+export interface MidnightMonitorConfig {
+  networkId: NetworkId;
+  indexerUrl: string;
+  indexerWsUrl: string;
+  nodeUrl: string;
+  proofServerUrl: string;
+  /**
+   * Address of the deployed central signet contract. The responder both POLLS
+   * its notification registry to discover requests (via
+   * {@link SignetRequestFeed}) and posts its responses here — one contract for
+   * both directions.
+   */
+  signetContractAddress: string;
+  mpcRootKey: string;
+  pollIntervalMs?: number;
+  wsPort?: number;
+
+  /**
+   * responderWalletSeed is the seed of midnight wallet from which responses are to be done.
+   * Defaults to genesis account seed.
+   */
+  responderWalletSeed?: string;
+}
+
+/** The responder's live wallet: its key material plus a started-and-synced facade. */
+export interface ResponderWallet {
+  keys: AccountKeys;
+  walletFacade: WalletFacade;
+}
+
+/**
+ * The joined signet contract handle — midnight-js's found-contract shape typed
+ * to the generated contract, so `callTx.postSignatureResponse(...)` and
+ * `callTx.postRespondBidirectional(...)` carry the real circuit signatures.
+ */
+type DeployedSignetContract = FoundContract<
+  SignetContract<SignetContractPrivateState>
+>;
+
+(globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+
+/**
+ * Upper bound on a single signet contract write (proof + submit + finalize).
+ * Long by design — a real attestation legitimately takes tens of seconds; this
+ * only trips when a `callTx` is genuinely wedged, turning a forever-hang into a
+ * retryable failure.
+ */
+const WRITE_TIMEOUT_MS = 120_000;
+
+export class MidnightMonitor {
+  private config: MidnightMonitorConfig;
+  private pollIntervalId: NodeJS.Timeout | null = null;
+  private polling = false;
+
+  private publicDataProvider: PublicDataProvider | null = null;
+
+  // The registry-polling request feed: polls the ONE signet contract's
+  // notification registry, resolves each entry to an authenticated request
+  // read from the caller's own ledger, and dedupes by request id. Built in
+  // initialize().
+  private feed: SignetRequestFeed | null = null;
+
+  // The responder wallet and the joined signet contract are both
+  // constructed lazily on first access and memoized (loaded once). The cached
+  // promise is cleared if construction rejects, so a later call can retry.
+  private responderWalletPromise?: Promise<ResponderWallet>;
+  private responderContractPromise?: Promise<DeployedSignetContract>;
+
+  // The MPC root key bytes; each RespondBidirectionalEvent is signed with
+  // the RESPONSE key derived per requesting contract from (root key, the
+  // request's sender address, the fixed "midnight response key" path).
+  private mpcRootKeyBytes: Uint8Array | null = null;
+
+  // Single-writer serialization for ALL signet contract writes. The joined
+  // contract shares one wallet + single-writer LevelDB private-state store, and
+  // two concurrent callTx.* invocations deadlock it (see the poll-loop note in
+  // start()). postSignatureResponse and postRespondBidirectional are driven by
+  // two INDEPENDENT loops (MidnightMonitor's poll and ChainSignatureServer's tx
+  // monitor), so their per-loop re-entrancy guards don't cover cross-loop
+  // overlap. This chain forces every write to queue behind the previous one.
+  private writeChain: Promise<unknown> = Promise.resolve();
+
+  constructor(config: MidnightMonitorConfig) {
+    this.config = {
+      pollIntervalMs: 5000,
+      wsPort: 3030,
+      ...config,
+    };
+  }
+
+  async initialize(): Promise<void> {
+    console.log('MidnightMonitor: Initializing (generic signet monitor)...');
+
+    this.mpcRootKeyBytes = new Uint8Array(
+      Buffer.from(this.config.mpcRootKey.replace('0x', ''), 'hex')
+    );
+    console.log(
+      'MidnightMonitor: respond-bidirectional response keys are derived per' +
+        ' requesting contract (sender-scoped, "midnight response key" path)'
+    );
+
+    this.publicDataProvider = indexerPublicDataProvider({
+      queryURL: this.config.indexerUrl,
+      subscriptionURL: this.config.indexerWsUrl,
+    });
+
+    // One feed over the central signet contract's notification registry — no
+    // requester list. The indexer provider is the state source for both the
+    // registry poll and the caller-ledger reads the resolver does.
+    this.feed = new SignetRequestFeed({
+      signetContractAddress: this.config.signetContractAddress,
+      source: this.publicDataProvider,
+    });
+
+    console.log(
+      `MidnightMonitor: polling signet contract registry at ${this.config.signetContractAddress}`
+    );
+    console.log('MidnightMonitor: Initialized (no compiled contract needed)');
+  }
+
+  // ---- Polling ----
+
+  async start(handlers: {
+    onSigningRequest: (request: MidnightSigningRequest) => Promise<void>;
+  }): Promise<void> {
+    console.log('MidnightMonitor: Starting polling...');
+    console.log(`  Indexer: ${this.config.indexerUrl}`);
+    console.log(
+      `  Signet contract (notification registry): ${this.config.signetContractAddress}`
+    );
+
+    this.pollIntervalId = setInterval(async () => {
+      // Non-re-entrant: wallet construction/sync and contract writes can take
+      // several seconds — longer than the poll interval. Skip a tick while the
+      // previous one is still running, or overlapping polls would issue
+      // concurrent writes to the single-writer LevelDB private-state store and
+      // deadlock on its lock (LEVEL_LOCKED).
+      if (this.polling) return;
+      this.polling = true;
+      try {
+        await this.fetchAndProcessRequests(handlers.onSigningRequest);
+      } catch (error) {
+        console.error('MidnightMonitor: Poll error:', error);
+      } finally {
+        this.polling = false;
+      }
+    }, this.config.pollIntervalMs);
+  }
+
+  async stop(): Promise<void> {
+    if (this.pollIntervalId) {
+      clearInterval(this.pollIntervalId);
+      this.pollIntervalId = null;
+    }
+
+    // Tear down the responder wallet facade — but only if it was ever
+    // constructed (lazy: an untouched monitor has no facade to stop).
+    if (this.responderWalletPromise) {
+      try {
+        const { walletFacade } = await this.responderWalletPromise;
+        await walletFacade.stop().catch(() => {});
+      } catch {
+        // Wallet construction failed earlier; nothing to stop.
+      }
+      this.responderWalletPromise = undefined;
+      this.responderContractPromise = undefined;
+    }
+
+    console.log('MidnightMonitor: Stopped');
+  }
+
+  // ---- Responder wallet + signet contract (lazy) ----
+
+  /** The Midnight network endpoints this responder runs against. */
+  private get nodeConfig(): MidnightNodeConfig {
+    return {
+      networkId: this.config.networkId,
+      indexerUrl: this.config.indexerUrl,
+      indexerWsUrl: this.config.indexerWsUrl,
+      nodeUrl: this.config.nodeUrl,
+      proofServerUrl: this.config.proofServerUrl,
+    };
+  }
+
+  /**
+   * The responder's started-and-synced wallet. Constructed on first access and
+   * memoized — later calls reuse the same instance. Torn down by {@link stop}.
+   */
+  async responderWallet(): Promise<ResponderWallet> {
+    if (!this.responderWalletPromise) {
+      this.responderWalletPromise = this.buildResponderWallet().catch(
+        (error) => {
+          this.responderWalletPromise = undefined; // allow a later retry
+          throw error;
+        }
+      );
+    }
+    return this.responderWalletPromise;
+  }
+
+  private async buildResponderWallet(): Promise<ResponderWallet> {
+    const seed = this.config.responderWalletSeed;
+    if (!seed) {
+      throw new Error(
+        'MidnightMonitor: responderWalletSeed is required to construct the responder wallet.'
+      );
+    }
+    console.log(
+      'MidnightMonitor: constructing responder wallet (derive keys -> start facade -> sync)...'
+    );
+    const keys = deriveAccountKeys(seed, this.config.networkId);
+    const walletFacade = await initialiseWalletFacade(keys, this.nodeConfig);
+    await walletFacade.start(keys.shieldedSecretKeys, keys.dustSecretKey);
+    await walletFacade.waitForSyncedState();
+    console.log('MidnightMonitor: responder wallet synced');
+    return { keys, walletFacade };
+  }
+
+  /**
+   * The joined signet contract, built on first access and memoized (depends on
+   * {@link responderWallet}). Its `callTx.postSignatureResponse` /
+   * `callTx.postRespondBidirectional` are the responder's on-chain write paths.
+   */
+  async responderContract(): Promise<DeployedSignetContract> {
+    if (!this.responderContractPromise) {
+      this.responderContractPromise = this.buildResponderContract().catch(
+        (error) => {
+          this.responderContractPromise = undefined; // allow a later retry
+          throw error;
+        }
+      );
+    }
+    return this.responderContractPromise;
+  }
+
+  private async buildResponderContract(): Promise<DeployedSignetContract> {
+    const contractAddress = this.config.signetContractAddress;
+    if (!contractAddress) {
+      throw new Error(
+        'MidnightMonitor: signetContractAddress is required to join the signet contract.'
+      );
+    }
+    const { keys, walletFacade } = await this.responderWallet();
+    // midnight-js reads a process-global network id — set it before building
+    // providers / joining the contract.
+    setNetworkId(this.config.networkId);
+    const providers = buildSignetContractProviders(
+      walletFacade,
+      keys,
+      this.nodeConfig
+    );
+    console.log(
+      `MidnightMonitor: joining signet contract at ${contractAddress}...`
+    );
+    return findDeployedContract(providers, {
+      contractAddress,
+      compiledContract: makeSignetContractCompiledContract(packagedManagedPath),
+      privateStateId: SIGNET_CONTRACT_PRIVATE_STATE_ID,
+      initialPrivateState: createSignetContractPrivateState(),
+    });
+  }
+
+  /**
+   * Serialize an on-chain write behind every prior one. The joined signet
+   * contract shares a single wallet + LevelDB private-state store, so concurrent
+   * `callTx.*` calls deadlock; chaining forces them to run one at a time.
+   */
+  private serializeWrite<T>(post: () => Promise<T>): Promise<T> {
+    const result = this.writeChain.then(post, post);
+    // Keep the chain alive past a rejection so one failed write doesn't wedge
+    // every subsequent write, and swallow the tail rejection (the real error is
+    // still delivered to the caller via `result`).
+    this.writeChain = result.catch(() => {});
+    return result;
+  }
+
+  /**
+   * Run one on-chain post and log how long it took (proof generation +
+   * submission + finalization) — basic latency benchmarking of the signet
+   * contract write paths. Logs on failure too, so timeouts are measurable.
+   *
+   * Bounded by {@link WRITE_TIMEOUT_MS}: a genuinely wedged `callTx` (e.g. a
+   * submission that never lands) rejects instead of hanging forever, so the
+   * request is marked failed and retried on the next poll rather than silently
+   * blocking the write chain. The timeout is deliberately long — a real
+   * attestation proof + submit legitimately takes tens of seconds.
+   */
+  private async timedPost<T>(
+    label: string,
+    post: () => Promise<T>
+  ): Promise<T> {
+    console.log(`MidnightMonitor: [timing] ${label} started...`);
+    const startedAt = performance.now();
+    let timeoutId: NodeJS.Timeout | undefined;
+    try {
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () =>
+            reject(
+              new Error(`${label} timed out after ${WRITE_TIMEOUT_MS / 1000}s`)
+            ),
+          WRITE_TIMEOUT_MS
+        );
+      });
+      const result = await Promise.race([post(), timeout]);
+      const seconds = ((performance.now() - startedAt) / 1000).toFixed(1);
+      console.log(`MidnightMonitor: [timing] ${label} took ${seconds}s`);
+      return result;
+    } catch (error) {
+      const seconds = ((performance.now() - startedAt) / 1000).toFixed(1);
+      console.log(
+        `MidnightMonitor: [timing] ${label} FAILED after ${seconds}s`
+      );
+      throw error;
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Post an MPC signature response (the canonical `{ bigR, s, recoveryId }`
+   * record) on-chain via the joined signet contract. Unauthenticated by
+   * necessity — verified off-chain. Lazily constructs the wallet + contract on
+   * first call.
+   */
+  async postSignatureResponse(
+    requestId: Uint8Array,
+    signatureResponse: SignatureRespondedEvent
+  ) {
+    // Resolve the contract OUTSIDE the timer: the first call builds the
+    // wallet + joins the contract (separately logged), and that one-off cost
+    // would skew the post benchmark.
+    const contract = await this.responderContract();
+    return this.serializeWrite(() =>
+      this.timedPost(
+        `postSignatureResponse(0x${Buffer.from(requestId).toString('hex')})`,
+        () =>
+          contract.callTx.postSignatureResponse(requestId, signatureResponse)
+      )
+    );
+  }
+
+  /**
+   * Post the MPC's respond-bidirectional response on-chain via the joined
+   * signet contract. Stored UNVERIFIED (the signet contract is an append-only
+   * log): clients verify the ECDSA signature over the attestation digest of
+   * (requestId, serializedOutput, outputLen) against the response key their
+   * deploy pinned. Lazily constructs the wallet + contract on first call.
+   */
+  async postRespondBidirectional(
+    requestId: Uint8Array,
+    respondBidirectional: RespondBidirectionalEvent
+  ) {
+    const contract = await this.responderContract();
+    return this.serializeWrite(() =>
+      this.timedPost(
+        `postRespondBidirectional(0x${Buffer.from(requestId).toString('hex')})`,
+        () =>
+          contract.callTx.postRespondBidirectional(
+            requestId,
+            respondBidirectional
+          )
+      )
+    );
+  }
+
+  private async fetchAndProcessRequests(
+    onSigningRequest: (request: MidnightSigningRequest) => Promise<void>
+  ): Promise<void> {
+    if (!this.feed) {
+      console.error('MidnightMonitor: not initialized');
+      return;
+    }
+
+    // Discover by registry poll: the feed reads the signet contract's notifications,
+    // resolves each to an AUTHENTICATED request from the named caller's own
+    // ledger (forged / not-yet-indexed / non-member notifications are dropped and
+    // retried), and dedupes by request id. No requester contract list.
+    let resolved: ResolvedSignetRequest[];
+    try {
+      resolved = await this.feed.poll();
+    } catch (error) {
+      console.error('MidnightMonitor: Error polling signet registry:', error);
+      return;
+    }
+
+    for (const {
+      callerAddress,
+      requestId,
+      request: signetRequest,
+    } of resolved) {
+      console.log(
+        `MidnightMonitor: New request ${requestId} from contract ${callerAddress}`
+      );
+      const request = this.toSigningRequest(
+        callerAddress,
+        requestId,
+        signetRequest
+      );
+      console.log(
+        `  Selector: ${request.calldata.selector ?? '(no calldata)'}`
+      );
+      console.log(
+        `  Words: ${request.calldata.words.map((word) => `0x${bytesToHex(word)}`).join(', ')}`
+      );
+
+      try {
+        await onSigningRequest(request);
+      } catch (error) {
+        console.error(`MidnightMonitor: Error processing ${requestId}:`, error);
+        // Re-arm for redelivery on the next poll — mirrors the old
+        // delete-from-processed retry, now driven by the feed's dedupe set.
+        this.feed.forget(requestId);
+      }
+    }
+  }
+
+  /**
+   * Adapt an authenticated {@link SignBidirectionalEvent} (read from the
+   * requester contract `predecessor`'s ledger) into the flat
+   * {@link MidnightSigningRequest} the signing pipeline consumes. `predecessor`
+   * is the epsilon-derivation root — the contract whose authenticated state the
+   * feed actually read, never a value taken from the notification on faith.
+   */
+  private toSigningRequest(
+    predecessor: string,
+    requestId: RequestIdHex,
+    signetRequest: SignBidirectionalEvent
+  ): MidnightSigningRequest {
+    const { txParams } = signetRequest;
+    // The flat logging view of the calldata: the real (used) words.
+    // Re-assembly itself happens in the shared builder.
+    const words = txParams.calldata.is_some
+      ? txParams.calldata.value.words.slice(
+          0,
+          Number(txParams.calldata.value.noWords)
+        )
+      : [];
+
+    return {
+      predecessor,
+      requestId: new Uint8Array(Buffer.from(requestId, 'hex')),
+      nonce: signetRequest.requestNonce,
+      evmParams: {
+        evmTo: txParams.to,
+        evmChainId: txParams.chainId,
+        evmNonce: txParams.nonce,
+        evmGasLimit: txParams.gasLimit,
+        evmMaxFee: txParams.maxFeePerGas,
+        evmPriorityFee: txParams.maxPriorityFeePerGas,
+        evmValue: txParams.value,
+      },
+      calldata: {
+        selector: txParams.calldata.is_some
+          ? `0x${bytesToHex(txParams.calldata.value.selector)}`
+          : undefined,
+        words,
+      },
+      caip2Id: decodePaddedString(signetRequest.caip2Id),
+      keyVersion: Number(signetRequest.keyVersion),
+      path: signetRequest.path,
+      // algo/dest are Compact enums (0-based variant indices) on the wire;
+      // the flat view keeps the historical string labels.
+      algo:
+        signetRequest.algo === MPCSignatureAlgorithm.ecdsa
+          ? 'ecdsa'
+          : `unknown(${signetRequest.algo})`,
+      dest:
+        signetRequest.dest === MPCDestination.unused
+          ? 'unused'
+          : `unknown(${signetRequest.dest})`,
+      params: signetRequest.params,
+      outputDeserializationSchema: signetRequest.outputDeserializationSchema,
+      respondSerializationSchema: signetRequest.respondSerializationSchema,
+      signetRequest,
+    };
+  }
+
+  // ---- Transaction building & signing ----
+
+  buildSerializedTransaction(request: MidnightSigningRequest): Uint8Array {
+    // Reuse signet-midnight's canonical builder (the same package the request
+    // reader comes from) rather than a vendored RLP re-implementation, so the
+    // unsigned transaction is assembled exactly as clients verify it.
+    const unsignedTx = signBidirectionalEventToUnsignedEVMTransaction(
+      request.signetRequest
+    );
+    return ethers.getBytes(unsignedTx.unsignedSerialized);
+  }
+
+  /**
+   * Sign and post the respond-bidirectional response for a completed (or
+   * failed) remote execution. `senderContractAddress` is the requesting
+   * contract (the request's sender field / the resolver's predecessor): the
+   * response key is derived from it, mirroring the real MPC's sender-scoped
+   * `tx.epsilon(path)` derivation.
+   */
+  async signAndBroadcastResponse(
+    requestId: Uint8Array,
+    evmReturnData: Uint8Array,
+    senderContractAddress: string
+  ): Promise<SignedResponse> {
+    const mpcRootKeyBytes = this.mpcRootKeyBytes;
+    if (!mpcRootKeyBytes) {
+      throw new Error('MidnightMonitor: not initialized (no root key)');
+    }
+    const responseSecretKey = deriveMidnightResponseSecretKey(
+      mpcRootKeyBytes,
+      senderContractAddress
+    );
+    const requestIdHex = Buffer.from(requestId).toString('hex');
+    console.log(
+      `MidnightMonitor: Signing respond-bidirectional response for ${requestIdHex}` +
+        ` (sender ${senderContractAddress}, response key ${formatSecp256k1PublicKey(
+          secp256k1PublicKeyOf(responseSecretKey)
+        )})`
+    );
+
+    if (evmReturnData.length > SERIALIZED_OUTPUT_BYTES) {
+      throw new Error(
+        `MidnightMonitor: execution output is ${evmReturnData.length} bytes — ` +
+          `does not fit the ${SERIALIZED_OUTPUT_BYTES}-byte serializedOutput field`
+      );
+    }
+    const serializedOutput = new Uint8Array(SERIALIZED_OUTPUT_BYTES);
+    serializedOutput.set(evmReturnData);
+    const outputLen = BigInt(evmReturnData.length);
+
+    // ECDSA-sign the attestation digest of (requestId, serializedOutput,
+    // outputLen) with the derived response key. The digest comes from the
+    // same compiled circuit client contracts verify against
+    // (verifyRespondBidirectionalEvent), so the response verifies at claim
+    // time. Signature scalars land as 32 little-endian bytes, the ledger form.
+    const digest = signetCircuits.signetAttestationDigest(
+      requestId,
+      serializedOutput,
+      outputLen
+    );
+    const sig = signAttestationDigest(digest, responseSecretKey);
+    const respondBidirectionalEvent: RespondBidirectionalEvent = {
+      serializedOutput,
+      outputLen,
+      r: bigintToBytes32(sig.r),
+      s: bigintToBytes32(sig.s),
+      recoveryId: BigInt(sig.recoveryId),
+    };
+
+    const response: SignedResponse = {
+      requestId: requestIdHex,
+      serializedOutput: Buffer.from(serializedOutput).toString('hex'),
+      outputLen: evmReturnData.length,
+      r: Buffer.from(respondBidirectionalEvent.r).toString('hex'),
+      s: Buffer.from(respondBidirectionalEvent.s).toString('hex'),
+      recoveryId: sig.recoveryId,
+    };
+
+    // Post the response on-chain to the signet contract. There is no
+    // push/websocket channel — the contract's respondBidirectionalMap is
+    // the delivery surface; the client polls it, verifies it, and presents
+    // the record to claimDeposit().
+    await this.postRespondBidirectional(requestId, respondBidirectionalEvent);
+    console.log(
+      `MidnightMonitor: posted respond-bidirectional response for ${requestIdHex}`
+    );
+
+    return response;
+  }
+
+  /**
+   * Post the MPC's EVM signature for a request on-chain to the
+   * signet contract. The input is the fully-signed EVM
+   * transaction the MPC produced; we extract its ECDSA signature as the
+   * canonical `{ bigR, s, recoveryId }` record — the payload a poller
+   * recovers the signer from — and submit it via the joined contract's
+   * `postSignatureResponse` circuit.
+   */
+  async broadcastSignedTransaction(data: {
+    requestId: string;
+    signedTransaction: string;
+    txHash: string;
+  }): Promise<void> {
+    // The signature covers the transaction's unsigned hash, which is exactly
+    // what a poller recovers the signer from (see signet-midnight's
+    // recoverSignatureResponseSigner). The record encoder recovers
+    // bigR.y by decompressing (r, yParity) on the curve.
+    const sig = ethers.Transaction.from(data.signedTransaction).signature;
+    if (!sig) {
+      throw new Error(
+        `broadcastSignedTransaction: transaction for ${data.requestId} carries no signature`
+      );
+    }
+    const signatureResponse = signatureToSignatureRespondedEvent(sig);
+
+    const requestId = ethers.getBytes(data.requestId);
+
+    console.log(
+      `MidnightMonitor: posting signature response for ${data.requestId} (tx ${data.txHash})...`
+    );
+    await this.postSignatureResponse(requestId, signatureResponse);
+    console.log(
+      `MidnightMonitor: posted signature response for ${data.requestId}`
+    );
+  }
+
+  /**
+   * The respond-bidirectional response public key for one requesting
+   * contract, as uncompressed SEC1 hex (null before initialize()). What the
+   * contract should pin via its initialise circuit.
+   */
+  getResponsePublicKey(senderContractAddress: string): string | null {
+    return this.mpcRootKeyBytes
+      ? formatSecp256k1PublicKey(
+          secp256k1PublicKeyOf(
+            deriveMidnightResponseSecretKey(
+              this.mpcRootKeyBytes,
+              senderContractAddress
+            )
+          )
+        )
+      : null;
+  }
+
+  getPathHex(request: MidnightSigningRequest): string {
+    return Buffer.from(request.path).toString('hex');
+  }
+
+  getPath(request: MidnightSigningRequest): string {
+    return Buffer.from(request.path).toString('utf8').replace(/\0/g, '');
+  }
+
+  static fromServerConfig(config: ServerConfig): MidnightMonitor | null {
+    // The signet contract address is now the sole requirement: the responder
+    // discovers requesters by polling its notification registry, so no requester list is
+    // needed (or accepted).
+    if (!config.midnightIndexerUrl || !config.midnightSignetContractAddress) {
+      return null;
+    }
+
+    return new MidnightMonitor({
+      networkId: (config.midnightNetworkId ?? 'undeployed') as NetworkId,
+      indexerUrl: config.midnightIndexerUrl,
+      indexerWsUrl:
+        config.midnightIndexerWsUrl ||
+        config.midnightIndexerUrl.replace('http', 'ws'),
+      nodeUrl: config.midnightNodeUrl || 'http://localhost:9944',
+      proofServerUrl: config.midnightProofServerUrl || 'http://localhost:6300',
+      signetContractAddress: config.midnightSignetContractAddress,
+      mpcRootKey: config.mpcRootKey,
+      responderWalletSeed:
+        config.midnightWalletSeed ||
+        '0000000000000000000000000000000000000000000000000000000000000001',
+    });
+  }
+}
+
+function decodePaddedString(bytes: Uint8Array): string {
+  let end = bytes.length;
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] === 0) {
+      end = i;
+      break;
+    }
+  }
+  return new TextDecoder().decode(bytes.slice(0, end));
+}

--- a/fakenet-signer/src/modules/midnight/midnight-node-config.ts
+++ b/fakenet-signer/src/modules/midnight/midnight-node-config.ts
@@ -1,0 +1,36 @@
+// Midnight node connection config — everything needed to talk to one Midnight
+// network. Ported from @midnight-erc20-vault/lib's midnight-node-config.ts, kept
+// to the type + a WS-derivation helper: this server supplies explicit endpoints
+// from its own ServerConfig/env layer, so the lib's env reader and per-network
+// endpoint defaults are intentionally NOT ported here.
+
+import type { NetworkId } from './network-id';
+
+/**
+ * The set of endpoints (+ network id) needed to reach the chain. Plain data,
+ * so it can be handed to functions by argument rather than reaching for a
+ * global. A seed is intentionally NOT part of this: this config describes a
+ * *network*, while a seed identifies a *wallet*.
+ */
+export interface MidnightNodeConfig {
+  readonly indexerUrl: string; // indexer GraphQL over HTTP
+  readonly indexerWsUrl: string; // indexer GraphQL over WebSocket (subscriptions / sync)
+  readonly nodeUrl: string; // Midnight node RPC (HTTP; converted to ws:// for the facade relay)
+  readonly proofServerUrl: string; // proof server (ZK proof generation)
+  readonly networkId: NetworkId; // which network these endpoints belong to
+}
+
+export type Endpoints = Omit<MidnightNodeConfig, 'networkId'>;
+
+// The proof server sees private witness data, so it is always run locally
+// rather than against a remote host.
+export const LOCAL_PROOF_SERVER = 'http://127.0.0.1:6300';
+
+// Derive the indexer WebSocket URL from the indexer HTTP URL: swap the scheme
+// to ws(s) and append the "/ws" path segment the indexer expects.
+export function indexerWsUrlFromIndexerUrl(indexerUrl: string): string {
+  const url = new URL(indexerUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/ws`;
+  return url.toString();
+}

--- a/fakenet-signer/src/modules/midnight/network-id.ts
+++ b/fakenet-signer/src/modules/midnight/network-id.ts
@@ -1,0 +1,27 @@
+// Network identity — the single source of named network ids.
+//
+// midnight-js types a network id as a bare `string` (`NetworkId`) with no
+// companion enum, so the named values live here. Convention: a network id is
+// ALWAYS named `networkId` and ALWAYS typed `NetworkId`.
+import type { NetworkId as MidnightSDKNetworkId } from '@midnight-ntwrk/midnight-js/network-id';
+
+/** A Midnight network id: the SDK's bare-string type plus our known named networks. */
+export type NetworkId =
+  // Include the SDK type so we stay assignable if it ever narrows.
+  | MidnightSDKNetworkId
+  // Local standalone stack (Docker node + indexer + proof server on localhost).
+  | 'undeployed'
+  // Public test network for early/breaking changes — bleeding-edge ledger.
+  | 'preview'
+  // Public test network that mirrors mainnet config; the final staging step.
+  | 'preprod'
+  // Production network (live, real value).
+  | 'mainnet';
+
+// All known network ids, for runtime validation and iteration.
+export const NETWORK_IDS: readonly NetworkId[] = [
+  'undeployed',
+  'preview',
+  'preprod',
+  'mainnet',
+];

--- a/fakenet-signer/src/modules/midnight/seed.ts
+++ b/fakenet-signer/src/modules/midnight/seed.ts
@@ -1,0 +1,122 @@
+// Seed parsing — turns user input (a BIP-39 mnemonic or a raw hex seed) into
+// the seed bytes the HD wallet derives from, plus a record of how it was
+// supplied (so the normalised hex form can be used as a stable identifier).
+import * as bip39 from '@scure/bip39';
+import { wordlist as english } from '@scure/bip39/wordlists/english.js';
+
+const toHex = (bytes: Uint8Array) =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+
+/** How the input seed was supplied. (Const object + union — see network.ts.) */
+export const SeedFormat = {
+  Mnemonic: 'mnemonic',
+  Hex: 'hex',
+} as const;
+// eslint-disable-next-line no-redeclare -- TS declaration merging (const object + union type)
+export type SeedFormat = (typeof SeedFormat)[keyof typeof SeedFormat];
+
+/** Where a parsed seed came from, including its normalised hex form. */
+export interface DerivationSource {
+  format: SeedFormat;
+  /** Word count, when the input was a mnemonic. */
+  words?: number;
+  /** The normalised hex of the seed bytes — the stable dedup key. */
+  seedHex: string;
+  seedBytes: number;
+}
+
+export class ParseError extends Error {}
+
+/**
+ * Parse `input` as a hex seed (16–64 bytes, optional 0x prefix) or a BIP-39
+ * mnemonic (run through PBKDF2 to its 64-byte seed). Throws {@link ParseError}
+ * when it is neither.
+ */
+export function parseSeed(input: string): {
+  seed: Uint8Array;
+  source: DerivationSource;
+} {
+  const trimmed = input.trim();
+  if (!trimmed)
+    throw new ParseError('Nothing to parse — generate or paste a seed first.');
+
+  const compact = trimmed.replace(/^0x/i, '');
+  const looksHex = /^[0-9a-fA-F]+$/.test(compact) && compact.length % 2 === 0;
+
+  if (looksHex) {
+    const bytes = compact.length / 2;
+    if (bytes < 16 || bytes > 64) {
+      throw new ParseError(`Hex seed must be 16–64 bytes; got ${bytes}.`);
+    }
+    const seed = Uint8Array.from({ length: bytes }, (_, i) =>
+      parseInt(compact.slice(i * 2, i * 2 + 2), 16)
+    );
+    return {
+      seed,
+      source: {
+        format: SeedFormat.Hex,
+        seedHex: compact.toLowerCase(),
+        seedBytes: bytes,
+      },
+    };
+  }
+
+  const words = trimmed.split(/\s+/);
+  if (!bip39.validateMnemonic(words.join(' '), english)) {
+    throw new ParseError('Not a valid BIP-39 mnemonic (and not valid hex).');
+  }
+  const seed = bip39.mnemonicToSeedSync(words.join(' '));
+  return {
+    seed,
+    source: {
+      format: SeedFormat.Mnemonic,
+      words: words.length,
+      seedHex: toHex(seed),
+      seedBytes: seed.length,
+    },
+  };
+}
+
+/** Generate a fresh random 24-word BIP-39 mnemonic (256 bits of entropy). */
+export function generateMnemonic(): string {
+  return bip39.generateMnemonic(english, 256);
+}
+
+/**
+ * Resolve a 32-byte identity secret key from the environment: `env[envVar]`
+ * (hex, optional 0x prefix) when set, else the bytes of `fallbackSeed` (the
+ * wallet seed doubling as the identity). Contract packages use this for the
+ * secret whose commitment gates a circuit (e.g. the vault deployer identity),
+ * and clients use it for the caller identity answering a secret-key witness.
+ *
+ * @param envVar - Name of the environment variable holding the hex secret.
+ * @param env - The environment to read from.
+ * @param fallbackSeed - The wallet seed (hex or mnemonic) used as the identity when `env[envVar]` is unset.
+ * @returns The 32-byte secret key.
+ * @throws If `env[envVar]` is set but not 32 bytes of hex, or if it is unset
+ * and `fallbackSeed` does not parse to exactly 32 bytes (e.g. a mnemonic).
+ */
+export function parseIdentitySecretKey(
+  envVar: string,
+  env: Record<string, string | undefined>,
+  fallbackSeed: string
+): Uint8Array {
+  const raw = env[envVar]?.trim();
+  if (raw) {
+    const hex = raw.replace(/^0x/i, '');
+    if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+      throw new ParseError(`${envVar} must be exactly 32 bytes of hex`);
+    }
+    return Uint8Array.from({ length: 32 }, (_, i) =>
+      parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+    );
+  }
+  const { seed } = parseSeed(fallbackSeed);
+  if (seed.length !== 32) {
+    throw new ParseError(
+      `The fallback seed parses to ${seed.length} bytes; the identity secret needs exactly 32. ` +
+        `Set ${envVar} explicitly.`
+    );
+  }
+  return seed;
+}

--- a/fakenet-signer/src/modules/midnight/signet-contract-providers.ts
+++ b/fakenet-signer/src/modules/midnight/signet-contract-providers.ts
@@ -1,0 +1,218 @@
+// This server's OWN midnight-js provider composition for the central signet
+// contract. @sig-net/midnight-contract is platform-agnostic and deliberately
+// ships no environment bindings — every consumer declares where zk artifacts
+// come from, where private state is stored, and how its wallet adapts to
+// midnight-js. This is the Node composition of THIS server, ported from
+// @midnight-erc20-vault/lib's midnight-providers.ts + deploy.ts (same pattern
+// as ./wallet and ./midnight-node-config).
+
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import { CompiledContract } from '@midnight-ntwrk/compact-js/effect';
+import { httpClientProvingProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+import {
+  createProofProvider,
+  ZKConfigRegistry,
+  zkConfigToProvingKeyMaterial,
+  type MidnightProvider,
+  type ProofProvider,
+  type UnboundTransaction,
+  type WalletProvider,
+  type ZKConfigProvider,
+} from '@midnight-ntwrk/midnight-js/types';
+import type {
+  ProvingKeyMaterial,
+  ProvingProvider,
+} from '@midnightntwrk/ledger-v9';
+import type { WalletFacade } from '@midnightntwrk/wallet-sdk-facade';
+import {
+  Contract,
+  SIGNET_CONTRACT_PRIVATE_STATE_ID,
+  type SignetContractCircuitId,
+  type SignetContractProviders,
+  type SignetContractPrivateState,
+} from '@sig-net/midnight-contract';
+
+import type { MidnightNodeConfig } from './midnight-node-config';
+import type { AccountKeys } from './wallet';
+
+/**
+ * The npm package's bundled compiler output (contract module, zkir, prover +
+ * verifier keys). Resolved through the package's `./managed/*` subpath export.
+ */
+export const packagedManagedPath = path.dirname(
+  path.dirname(
+    createRequire(import.meta.url).resolve(
+      '@sig-net/midnight-contract/managed/compiler/contract-manifest.json'
+    )
+  )
+);
+
+/**
+ * The signet-contract compact-js compiled-contract binding: generated module
+ * (the contract declares no witnesses) bound to on-disk compiled assets.
+ * Consumed by `findDeployedContract`.
+ *
+ * @param managedDirPath - The compiler output dir (`contract/`, `keys/`, `zkir/`).
+ * @returns The bound compiled contract.
+ */
+export function makeSignetContractCompiledContract(managedDirPath: string) {
+  const base = CompiledContract.make<
+    Contract<SignetContractPrivateState>,
+    SignetContractPrivateState
+  >('signet-contract', Contract);
+  const vacant = CompiledContract.withVacantWitnesses(base);
+  return CompiledContract.withCompiledFileAssets(vacant, managedDirPath);
+}
+
+// Balancing recipes expire 30 min out (same TTL the wallet-side submit uses).
+const BALANCE_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Adapt a started {@link WalletFacade} + {@link AccountKeys} to midnight-js's
+ * `WalletProvider & MidnightProvider`. `balanceTx` balances the unbound
+ * transaction with the account's shielded/dust keys, signs, then finalizes
+ * (which proves); `submitTx` relays through the facade. The casts bridge the
+ * midnight-js-protocol vs ledger-v9 nominal type identities of the same
+ * underlying classes.
+ */
+function createWalletAndMidnightProvider(
+  facade: WalletFacade,
+  keys: AccountKeys
+): WalletProvider & MidnightProvider {
+  return {
+    getCoinPublicKey: () => keys.shieldedSecretKeys.coinPublicKey,
+    getEncryptionPublicKey: () => keys.shieldedSecretKeys.encryptionPublicKey,
+    async balanceTx(tx: UnboundTransaction, ttl?: Date) {
+      const recipe = await facade.balanceUnboundTransaction(
+        tx as never,
+        {
+          shieldedSecretKeys: keys.shieldedSecretKeys,
+          dustSecretKey: keys.dustSecretKey,
+        },
+        { ttl: ttl ?? new Date(Date.now() + BALANCE_TTL_MS) }
+      );
+      const signed = await facade.signRecipe(
+        recipe,
+        keys.unshieldedKeystore.signDataAsync
+      );
+      return (await facade.finalizeRecipe(signed)) as never;
+    },
+    submitTx: (tx) => facade.submitTransaction(tx as never) as never,
+  };
+}
+
+/**
+ * Proof provider via the proof server's /check + /prove endpoints, with ZK key
+ * material resolved from the contract's compiled assets. Exists instead of
+ * midnight-js's own `httpClientProofProvider` because that one (5.0.0-beta.3)
+ * lacks the `lookupKey` the ledger-v9 1.0.0-rc.3 WASM validates for — delete
+ * in favor of `httpClientProofProvider` once midnight-js ships a beta aligned
+ * with ledger-v9 1.0.0-rc.3. (Ported from lib's createProofServerProvider.)
+ */
+function createProofServerProvider<K extends string>(
+  proofServerUrl: string,
+  zkConfigProvider: ZKConfigProvider<K>
+): ProofProvider {
+  const registry = new ZKConfigRegistry([
+    zkConfigProvider as ZKConfigProvider<string>,
+  ]);
+
+  // Pass the REGISTRY (not the provider) to the base: its /check and /prove
+  // key resolution special-cases a ZKConfigRegistry. The `as` bridges the
+  // nominal type: the base only ever calls `.resolveKeyLocation` on it.
+  const base = httpClientProvingProvider(
+    proofServerUrl,
+    registry as unknown as ZKConfigProvider<string>
+  );
+
+  const lookupKey = async (
+    keyLocation: string
+  ): Promise<ProvingKeyMaterial | undefined> => {
+    const resolved = await registry.resolveKeyLocation(keyLocation);
+    if (resolved !== undefined) {
+      return zkConfigToProvingKeyMaterial(resolved);
+    }
+    try {
+      return zkConfigToProvingKeyMaterial(
+        await zkConfigProvider.get(keyLocation as K)
+      );
+    } catch {
+      // Protocol builtins ("midnight/...") resolve to undefined and are
+      // supplied by the proof server itself.
+      return undefined;
+    }
+  };
+
+  const provingProvider: ProvingProvider = { ...base, lookupKey };
+  return createProofProvider(provingProvider);
+}
+
+/**
+ * Build this server's midnight-js provider set for the signet contract.
+ *
+ * @param facade - A started (and synced) wallet facade — see ./wallet.
+ * @param keys - The key material of the same wallet, for balancing and signing.
+ * @param config - The Midnight network endpoints to run against.
+ * @returns The provider set to hand to `findDeployedContract`.
+ */
+export function buildSignetContractProviders(
+  facade: WalletFacade,
+  keys: AccountKeys,
+  config: MidnightNodeConfig
+): SignetContractProviders {
+  // Retrieves the ZK artifacts of the contract needed to create proofs.
+  const zkConfigProvider = new NodeZkConfigProvider<SignetContractCircuitId>(
+    packagedManagedPath
+  );
+
+  // The wallet, adapted to midnight-js's balancer + submitter interfaces
+  // (the facade itself does not implement WalletProvider/MidnightProvider).
+  const walletAndMidnightProvider = createWalletAndMidnightProvider(
+    facade,
+    keys
+  );
+  const accountId = walletAndMidnightProvider.getCoinPublicKey();
+
+  return {
+    // Manages the private state of the contract, plus contract-maintenance
+    // signing keys. Store names are scoped to this server to avoid collision
+    // with other dApps sharing the same LevelDB. The signet contract's private
+    // state is empty, so nothing is lost if the store is cleared.
+    privateStateProvider: levelPrivateStateProvider({
+      privateStateStoreName: `${SIGNET_CONTRACT_PRIVATE_STATE_ID}-private-states`,
+      signingKeyStoreName: `${SIGNET_CONTRACT_PRIVATE_STATE_ID}-signing-keys`,
+      accountId,
+      // A constant in source is obfuscation, not secrecy — acceptable here
+      // only because nothing sensitive is stored (empty private state).
+      // Value unchanged from the pre-severing package so existing local
+      // stores still open.
+      privateStoragePasswordProvider: () => '&*(BHJqwe419-signetContract',
+    }),
+
+    // Retrieves public data from the blockchain.
+    publicDataProvider: indexerPublicDataProvider({
+      queryURL: config.indexerUrl,
+      subscriptionURL: config.indexerWsUrl,
+    }),
+
+    zkConfigProvider,
+
+    // Creates proven, unbalanced transactions (proves the contract-call
+    // transcript). Distinct from the wallet's own balancing proofs.
+    proofProvider: createProofServerProvider(
+      config.proofServerUrl,
+      zkConfigProvider
+    ),
+
+    // Creates proven, balanced transactions.
+    walletProvider: walletAndMidnightProvider,
+
+    // Submits proven, balanced transactions to the network.
+    midnightProvider: walletAndMidnightProvider,
+  };
+}

--- a/fakenet-signer/src/modules/midnight/signet-request-types.ts
+++ b/fakenet-signer/src/modules/midnight/signet-request-types.ts
@@ -1,0 +1,67 @@
+/**
+ * The fakenet responder's flat view of a Midnight signet signing request,
+ * decoded from a client contract's SignBidirectionalEvent record. Transaction
+ * re-assembly happens in @sig-net/midnight's shared builder
+ * (signBidirectionalEventToUnsignedEVMTransaction), never from this view:
+ * these fields exist for logging, routing and key derivation only.
+ */
+
+/** EVM gas parameters read from the request record. */
+export interface EvmGasParams {
+  /** Target EVM contract address (20 bytes). */
+  evmTo: Uint8Array;
+  /** EVM chain ID. */
+  evmChainId: bigint;
+  /** EVM transaction nonce. */
+  evmNonce: bigint;
+  /** Gas limit. */
+  evmGasLimit: bigint;
+  /** Max fee per gas (wei). */
+  evmMaxFee: bigint;
+  /** Max priority fee per gas (wei). */
+  evmPriorityFee: bigint;
+  /** ETH value to send (wei). */
+  evmValue: bigint;
+}
+
+/**
+ * Calldata fields read from the request record: the flat logging/inspection
+ * view of the word calldata. Words are ABI-ready big-endian 32-byte words,
+ * stored exactly as broadcast (selector || words, verbatim).
+ */
+export interface CalldataFields {
+  /** The 4-byte function selector as 0x hex; absent when the tx has no calldata. */
+  selector?: string;
+  /** The real (used) ABI-ready 32-byte calldata words, in order. */
+  words: Uint8Array[];
+}
+
+/** A signing request read from a client contract's signet ledger record. */
+export interface SigningRequest {
+  /** Contract address — the predecessor (from ContractCall.address). Unforgeable. */
+  predecessor: string;
+  /** Request ID — the Map key, computed as persistentHash of the full record. */
+  requestId: Uint8Array;
+  /** Per-request nonce value — ensures identical txs produce different request IDs. */
+  nonce: bigint;
+  /** EVM gas/tx parameters. */
+  evmParams: EvmGasParams;
+  /** Calldata fields (selector + words). */
+  calldata: CalldataFields;
+  /** CAIP-2 chain identifier, e.g. "eip155:11155111". */
+  caip2Id: string;
+  /** MPC key version. */
+  keyVersion: number;
+  /** Derivation path — controlled by the contract. */
+  path: Uint8Array;
+  /** Signing algorithm, e.g. "ecdsa". */
+  algo: string;
+  /** Destination type, e.g. "ethereum". */
+  dest: string;
+  /** Additional parameters (contract-specific). */
+  params: Uint8Array;
+  /** Schema for deserializing the EVM tx output. */
+  outputDeserializationSchema: Uint8Array;
+  /** Schema for serializing the response back. */
+  respondSerializationSchema: Uint8Array;
+}

--- a/fakenet-signer/src/modules/midnight/wallet.ts
+++ b/fakenet-signer/src/modules/midnight/wallet.ts
@@ -1,0 +1,111 @@
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { parseSeed } from './seed';
+import { NetworkId } from './network-id';
+import type { MidnightNodeConfig } from './midnight-node-config';
+import {
+  createKeystore,
+  PublicKey as UnshieldedPublicKey,
+  type UnshieldedKeystore,
+  UnshieldedWallet,
+} from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { HDWallet, Roles } from '@midnightntwrk/wallet-sdk-hd';
+import {
+  WalletFacade,
+  mergeWalletEntries,
+  WalletEntrySchema,
+} from '@midnightntwrk/wallet-sdk-facade';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
+import { InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+
+/**
+ * The fee settings the facade balances transactions with: it burns
+ * `feesWithMargin(params, feeBlocksMargin) + additionalFeeOverhead` per
+ * transaction.
+ */
+export const COST_PARAMETERS: {
+  readonly additionalFeeOverhead: bigint;
+  readonly feeBlocksMargin: number;
+} = {
+  additionalFeeOverhead: 300_000_000_000n,
+  feeBlocksMargin: 5,
+};
+
+/** The live key material for one account. Reused for signing / balancing. */
+export interface AccountKeys {
+  shieldedSecretKeys: ledger.ZswapSecretKeys;
+  dustSecretKey: ledger.DustSecretKey;
+  unshieldedKeystore: UnshieldedKeystore;
+}
+
+/**
+ * Parse a seed and derive the three role keys (Zswap / NightExternal / Dust).
+ * Pure crypto — no network. This is the step that exercises the ledger WASM.
+ */
+export function deriveAccountKeys(
+  seed: string,
+  networkId: NetworkId
+): AccountKeys {
+  const { seed: seedBytes } = parseSeed(seed);
+
+  const hd = HDWallet.fromSeed(seedBytes);
+  if (hd.type !== 'seedOk')
+    throw new Error('HDWallet.fromSeed failed (seedError).');
+
+  const derived = hd.hdWallet
+    .selectAccount(0)
+    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
+    .deriveKeysAt(0);
+  if (derived.type !== 'keysDerived')
+    throw new Error('deriveKeysAt failed (keyOutOfBounds).');
+  hd.hdWallet.clear();
+
+  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(
+    derived.keys[Roles.Zswap]
+  );
+  const dustSecretKey = ledger.DustSecretKey.fromSeed(derived.keys[Roles.Dust]);
+  const unshieldedKeystore = createKeystore(
+    { kind: 'schnorr', secret: derived.keys[Roles.NightExternal] },
+    networkId
+  );
+
+  return { shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+}
+
+/**
+ * Wire up the WalletFacade for the given keys + connection config. This only
+ * constructs the three sub-wallets — it does NOT start syncing.
+ */
+export function initialiseWalletFacade(
+  keys: AccountKeys,
+  config: MidnightNodeConfig
+): Promise<WalletFacade> {
+  return WalletFacade.init({
+    configuration: {
+      networkId: config.networkId,
+      indexerClientConnection: {
+        indexerHttpUrl: config.indexerUrl,
+        indexerWsUrl: config.indexerWsUrl,
+      },
+      provingServerUrl: new URL(config.proofServerUrl),
+      // The facade talks to the node over WebSocket, so flip http(s) -> ws(s).
+      relayURL: new URL(config.nodeUrl.replace(/^http/, 'ws')),
+      costParameters: COST_PARAMETERS,
+      txHistoryStorage: new InMemoryTransactionHistoryStorage(
+        WalletEntrySchema,
+        mergeWalletEntries
+      ),
+    },
+    shielded: (cfg) =>
+      ShieldedWallet(cfg).startWithSecretKeys(keys.shieldedSecretKeys),
+    unshielded: (cfg) =>
+      UnshieldedWallet(cfg).startWithPublicKey(
+        UnshieldedPublicKey.fromKeyStore(keys.unshieldedKeystore)
+      ),
+    dust: (cfg) =>
+      DustWallet(cfg).startWithSecretKey(
+        keys.dustSecretKey,
+        ledger.LedgerParameters.initialParameters().dust
+      ),
+  });
+}

--- a/fakenet-signer/src/server/ChainSignatureServer.ts
+++ b/fakenet-signer/src/server/ChainSignatureServer.ts
@@ -40,6 +40,10 @@ import {
   SubstrateMonitor,
   SubstrateSignatureRequest,
 } from '../modules/SubstrateMonitor';
+import {
+  MidnightMonitor,
+  type MidnightSigningRequest,
+} from '../modules/MidnightMonitor';
 
 const pendingTransactions = new Map<string, PendingTransaction>();
 
@@ -83,6 +87,7 @@ export class ChainSignatureServer {
   private backfillCycleCounter = 0;
   private lastBackfillSignature: string | undefined;
   private substrateMonitor: SubstrateMonitor | null = null;
+  private midnightMonitor: MidnightMonitor | null = null;
 
   constructor(config: ServerConfig) {
     try {
@@ -118,6 +123,7 @@ export class ChainSignatureServer {
     if (this.config.substrateWsUrl) {
       this.substrateMonitor = new SubstrateMonitor(this.config.substrateWsUrl);
     }
+    this.midnightMonitor = MidnightMonitor.fromServerConfig(this.config);
   }
 
   private setupSolana() {
@@ -187,6 +193,10 @@ export class ChainSignatureServer {
 
     if (this.substrateMonitor) {
       await this.connectToSubstrate();
+    }
+
+    if (this.midnightMonitor) {
+      await this.connectToMidnight();
     }
 
     // Chain-agnostic: tracks pending destination-chain txs (EVM/Bitcoin) for
@@ -276,6 +286,105 @@ export class ChainSignatureServer {
     } catch (error) {
       console.log({ error }, 'Failed to connect to Substrate');
     }
+  }
+
+  private async connectToMidnight() {
+    if (!this.midnightMonitor) return;
+
+    try {
+      await this.midnightMonitor.initialize();
+      console.log('Connected to Midnight network');
+
+      await this.midnightMonitor.start({
+        onSigningRequest: async (request: MidnightSigningRequest) => {
+          console.log(
+            `Midnight signing request: 0x${Buffer.from(request.requestId).toString('hex')} caip2=${request.caip2Id}`
+          );
+          try {
+            await this.handleMidnightSigningRequest(request);
+          } catch (error) {
+            console.error('Error processing Midnight signing request:', error);
+          }
+        },
+      });
+    } catch (error) {
+      console.error('Failed to connect to Midnight:', error);
+    }
+  }
+
+  /**
+   * Handle a signing request from the Midnight vault contract.
+   *
+   * The MPC reads calldata args + EVM gas params from the contract's ledger,
+   * builds ABI calldata + RLP transaction off-chain from contract-controlled values,
+   * signs with the derived secp256k1 key, and sends the signed tx to the client
+   * via WebSocket. The CLIENT broadcasts to Sepolia. The MPC monitors for the tx hash.
+   */
+  private async handleMidnightSigningRequest(request: MidnightSigningRequest) {
+    if (!this.midnightMonitor) return;
+
+    // Build the unsigned EVM transaction from contract-controlled calldata + gas params
+    const unsignedTxBytes =
+      this.midnightMonitor.buildSerializedTransaction(request);
+
+    // Derive the signing key using the contract's path field as the derivation
+    // path. The path is 32 opaque bytes of the client contract's choosing;
+    // the derivation-string rendering strips the zero padding (getPath).
+    const pathString = this.midnightMonitor.getPath(request);
+    const derivedPrivateKey = await CryptoUtils.deriveSigningKeyWithChainId(
+      pathString,
+      request.predecessor,
+      this.config.mpcRootKey,
+      'midnight:testnet'
+    );
+
+    // Parse the unsigned tx and sign it properly with ethers
+    const unsignedTx = ethers.Transaction.from(ethers.hexlify(unsignedTxBytes));
+    const wallet = new ethers.Wallet(derivedPrivateKey);
+    const signedTxHex = await wallet.signTransaction(unsignedTx);
+    const signedTx = ethers.Transaction.from(signedTxHex);
+    const signedTxHash = signedTx.hash;
+    if (!signedTxHash) {
+      throw new Error('Midnight: signed transaction has no hash');
+    }
+
+    console.log(`Midnight: Signed tx ${signedTxHash}`);
+    console.log(`  Signing address: ${wallet.address}`);
+
+    const requestIdHex = '0x' + Buffer.from(request.requestId).toString('hex');
+
+    // Post the MPC signature on-chain to the signet contract
+    // (the client polls it and broadcasts the EVM tx itself).
+    await this.midnightMonitor.broadcastSignedTransaction({
+      requestId: requestIdHex,
+      signedTransaction: signedTxHex,
+      txHash: signedTxHash,
+    });
+
+    // Store as pending transaction for the monitor to track.
+    // The client broadcasts to Sepolia; the MPC watches for confirmation.
+    pendingTransactions.set(signedTxHash, {
+      txHash: signedTxHash,
+      requestId: requestIdHex,
+      caip2Id: request.caip2Id,
+      explorerDeserializationSchema: Buffer.from(
+        request.outputDeserializationSchema
+      ),
+      callbackSerializationSchema: Buffer.from(
+        request.respondSerializationSchema
+      ),
+      fromAddress: wallet.address,
+      nonce: Number(unsignedTx.nonce),
+      checkCount: 0,
+      namespace: request.caip2Id.split(':')[0] ?? 'eip155',
+      prevouts: [],
+      sender: request.predecessor,
+      source: 'midnight',
+    });
+
+    console.log(
+      `Midnight: Monitoring EVM tx ${signedTxHash} (client will broadcast)`
+    );
   }
 
   private async ensureInitialized() {
@@ -483,6 +592,23 @@ export class ChainSignatureServer {
     }
     const requestIdBytes = Buffer.from(requestId.slice(2), 'hex');
 
+    if (txInfo.source === 'midnight' && this.midnightMonitor) {
+      // Midnight: ECDSA-sign the serialized output on-chain; the user
+      // polls the signet contract and claims.
+      const serializedOutput = await OutputSerializer.serialize(
+        result.output,
+        SerializationFormat.Midnight,
+        txInfo.callbackSerializationSchema
+      );
+      await this.midnightMonitor.signAndBroadcastResponse(
+        requestIdBytes,
+        serializedOutput,
+        txInfo.sender
+      );
+      console.log(`✓ Midnight: response posted for ${txHash}`);
+      return;
+    }
+
     this.log(`🔗 OutputSerializer: serialize...`);
     const serializedOutput = await OutputSerializer.serialize(
       result.output,
@@ -543,6 +669,30 @@ export class ChainSignatureServer {
     const requestIdBytes = Buffer.from(requestId.slice(2), 'hex');
 
     const MAGIC_ERROR_PREFIX = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+
+    if (txInfo.source === 'midnight' && this.midnightMonitor) {
+      // Midnight: deadbeef prefix + serialized error using respond schema.
+      // deadbeef in first 4 bytes makes claim() fail (byte 0 = 0xde != 0x01),
+      // and a future refund() circuit can detect it via slice<4>(outputData, 0).
+      const errorOutput = { success: false };
+      const serializedError = await OutputSerializer.serialize(
+        errorOutput,
+        SerializationFormat.Midnight,
+        txInfo.callbackSerializationSchema
+      );
+      const outputData = new Uint8Array(
+        MAGIC_ERROR_PREFIX.length + serializedError.length
+      );
+      outputData.set(MAGIC_ERROR_PREFIX);
+      outputData.set(serializedError, MAGIC_ERROR_PREFIX.length);
+      await this.midnightMonitor.signAndBroadcastResponse(
+        requestIdBytes,
+        outputData,
+        txInfo.sender
+      );
+      console.log(`✓ Midnight: error response posted for ${txHash}`);
+      return;
+    }
 
     const errorSchema = { struct: { error: 'bool' } };
     const borshData = borsh.serialize(errorSchema, { error: true });
@@ -1214,6 +1364,10 @@ export class ChainSignatureServer {
     if (this.substrateMonitor) {
       await this.substrateMonitor.disconnect();
       this.substrateMonitor = null;
+    }
+    if (this.midnightMonitor) {
+      await this.midnightMonitor.stop();
+      this.midnightMonitor = null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add MidnightMonitor for polling Midnight contracts via indexer
- Support multi-contract monitoring with per-contract nonce tracking
- Lazy nonce seeding to prevent replay of old requests on restart
- Add OutputSerializer for Midnight Schnorr response signing
- Derive signing keys from request predecessor (contract address)