### PR TITLE
docs: dedupe sign-bidirectional docs to the canonical page

### DIFF
--- a/signet-program/programs/signet/README.md
+++ b/signet-program/programs/signet/README.md
@@ -7,6 +7,10 @@ Solana program for cross-chain signature requests with verified response callbac
 This program enables users to request ECDSA signatures from the Signet MPC network,
 supporting both simple signing and bidirectional cross-chain transactions.
 
+> The chain-agnostic version of this flow — shared by all Signet source chains — is
+> documented at [Sign Bidirectional Flow](https://docs.sig.network/architecture/sign-bidirectional).
+> This README documents it in depth with the Solana specifics.
+
 ## Instructions Reference
 
 ### Developer Instructions

--- a/signet-program/programs/signet/README.md
+++ b/signet-program/programs/signet/README.md
@@ -7,6 +7,12 @@ Solana program for cross-chain signature requests with verified response callbac
 This program enables users to request ECDSA signatures from the Signet MPC network,
 supporting both simple signing and bidirectional cross-chain transactions.
 
+It is the **Solana source-chain implementation** of the Signet Sign Bidirectional
+protocol. The chain-agnostic lifecycle — flow phases, serialization schemas, error
+handling, address derivation, and security properties — is documented once in the
+[Sign Bidirectional Flow](https://docs.sig.network/architecture/sign-bidirectional)
+docs. This README covers only what is Solana-specific.
+
 ## Instructions Reference
 
 ### Developer Instructions
@@ -19,157 +25,44 @@ These are the primary instructions for building applications:
 | [`sign_bidirectional`](https://docs.rs/chain-signatures-solana-program/latest/chain_signatures/chain_signatures/fn.sign_bidirectional.html)       | Cross-chain tx with execution result callback    |
 | [`get_signature_deposit`](https://docs.rs/chain-signatures-solana-program/latest/chain_signatures/chain_signatures/fn.get_signature_deposit.html) | Query the current deposit amount (view function) |
 
-## Sign Bidirectional Flow
+## Sign Bidirectional on Solana
 
-The bidirectional flow enables cross-chain transaction execution with verified
-response callbacks:
+`sign_bidirectional` emits `SignBidirectionalEvent`; the MPC answers with
+`SignatureRespondedEvent` (the transaction signature — the user broadcasts, the MPC
+does not) and, after observing the destination chain, `RespondBidirectionalEvent`
+(the signed execution result). Failed destination transactions are reported with the
+`0xdeadbeef` magic prefix on the output.
 
-```text
-User                    Solana (Source)         MPC Network        Destination Chain
-  │                        │                         │                    │
-  │ sign_bidirectional()   │                         │                    │
-  ├───────────────────────►│                         │                    │
-  │                        │  SignBidirectionalEvent │                    │
-  │                        ├────────────────────────►│                    │
-  │                        │◄──── respond() ─────────┤                    │
-  │                        │                         │                    │
-  │ Poll SignatureRespondedEvent                     │                    │
-  │◄───────────────────────┤                         │                    │
-  │                        │                         │                    │
-  │ Broadcast signed tx ───┼─────────────────────────┼───────────────────►│
-  │                        │                         │◄── Light client ───┤
-  │                        │◄─ respond_bidirectional()                    │
-  │                        │                         │                    │
-  │ Poll RespondBidirectionalEvent                   │                    │
-  │◄───────────────────────┤                         │                    │
-```
+See the [Sign Bidirectional Flow](https://docs.sig.network/architecture/sign-bidirectional)
+for the full lifecycle diagram and phase-by-phase description.
 
-### Phase 1: Sign Request
+## Request ID Generation (Solana encoding)
 
-1. User calls `sign_bidirectional` with serialized unsigned transaction
-2. Program emits `SignBidirectionalEvent`
-3. MPC parses event and generates unique request ID
-
-### Phase 2: Signature Delivery
-
-1. MPC signs the transaction hash
-2. Stores transaction in backlog for observation
-3. Calls `respond`, emitting `SignatureRespondedEvent`
-4. User polls for `SignatureRespondedEvent` to get signature
-
-### Phase 3: User Broadcast
-
-1. User assembles signed transaction (serialized data + signature)
-2. User broadcasts to destination chain
-3. **The MPC does NOT broadcast** - this is the user's responsibility
-
-### Phase 4: Light Client Observation
-
-1. MPC light client monitors destination chain blocks
-2. Detects transaction confirmation by hash
-3. Extracts execution status (success/failure)
-
-### Phase 5: Output Extraction
-
-1. For contract calls: MPC extracts return value
-2. For simple transfers: empty success indicator
-3. Output deserialized using `output_deserialization_schema`
-
-### Phase 6: Respond Bidirectional
-
-1. MPC serializes output using `respond_serialization_schema`
-2. Signs `keccak256(request_id || serialized_output)`
-3. Calls `respond_bidirectional`
-4. Program emits `RespondBidirectionalEvent` for user to poll
-
-## Request ID Generation
-
-Each request has a unique ID for tracking:
+Each request has a unique ID for tracking. On Solana it uses **packed encoding**:
 
 ```text
-// For sign_bidirectional (packed encoding):
+// For sign_bidirectional:
 request_id = keccak256(
     sender || serialized_tx || caip2_id || key_version ||
     path || algo || dest || params
 )
 ```
 
-## Serialization Schemas
+## Response Signature Verification (Solana specifics)
 
-Cross-chain data encoding uses two schemas:
-
-| Schema                          | Direction         | Purpose                                         |
-| ------------------------------- | ----------------- | ----------------------------------------------- |
-| `output_deserialization_schema` | Destination → MPC | Parse execution result from destination chain   |
-| `respond_serialization_schema`  | MPC → Source      | Serialize response for source chain consumption |
-
-See destination chain guides (e.g., [EVM](https://docs.rs/chain-signatures-solana-program/latest/chain_signatures/evm/index.html)) for format details and examples.
-
-## Error Handling
-
-Failed destination chain transactions are indicated with magic prefix:
-
-```rust
-const MAGIC_ERROR_PREFIX: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
-
-// Check if response indicates failure:
-fn is_error(output: &[u8]) -> bool {
-    output.starts_with(&[0xde, 0xad, 0xbe, 0xef])
-}
-```
-
-## Address Derivation
-
-Each user gets a unique destination chain address derived from:
-
-```text
-epsilon = derive_epsilon(sender_pubkey, derivation_path)
-user_pubkey = derive_key(mpc_root_pubkey, epsilon)
-// Address format is chain-specific (see destination chain guides)
-```
-
-## Response Signature Verification
-
-The `respond_bidirectional` response is signed using a **special derivation path**:
+The `respond_bidirectional` response is signed over
+`keccak256(request_id || serialized_output)` using the **fixed Solana response
+derivation path**:
 
 ```text
 const RESPONSE_DERIVATION_PATH: &str = "solana response key";
-
-// Response epsilon derivation:
-epsilon = derive_epsilon(key_version, sender_pubkey, "solana response key")
-response_pubkey = derive_key(mpc_root_pubkey, epsilon)
 ```
 
-The signature is computed over:
-
-```text
-message_hash = keccak256(request_id || serialized_output)
-```
-
-To verify the response signature, clients must:
-
-1. Recover the public key from the signature using `secp256k1_recover`
-2. Derive the expected response public key using the `"solana response key"` path
-3. Compare the recovered public key with the expected response public key
-
-## Security Considerations
-
-### Security Properties
-
-1. **Request ID Uniqueness**: Each request has a unique ID computed from
-   `keccak256(sender || tx || chain_id || ...)` preventing replay attacks
-
-2. **Response Authenticity**: Responses are signed over
-   `keccak256(request_id || serialized_output)` using MPC threshold signatures
-
-3. **Output Verification**: The `output_deserialization_schema` and
-   `respond_serialization_schema` ensure consistent data encoding across chains
-
-4. **Key Isolation**: Each user has isolated keys through unique derivation paths
-   (`epsilon = derive_epsilon(predecessor, path)`)
-
-5. **Light Client Security**: The MPC light client validates destination chain
-   consensus without trusting an RPC provider
+To verify, recover the public key from the signature with `secp256k1_recover` and
+compare it against the response child key derived from the MPC root with the
+requester's `sender` and the `"solana response key"` path. Why a dedicated response
+key exists — and the generic derivation formula — is covered in the
+[canonical flow docs](https://docs.sig.network/architecture/sign-bidirectional#response-signature-verification).
 
 ## Destination Chain Guides
 

--- a/signet-program/programs/signet/README.md
+++ b/signet-program/programs/signet/README.md
@@ -7,12 +7,6 @@ Solana program for cross-chain signature requests with verified response callbac
 This program enables users to request ECDSA signatures from the Signet MPC network,
 supporting both simple signing and bidirectional cross-chain transactions.
 
-It is the **Solana source-chain implementation** of the Signet Sign Bidirectional
-protocol. The chain-agnostic lifecycle — flow phases, serialization schemas, error
-handling, address derivation, and security properties — is documented once in the
-[Sign Bidirectional Flow](https://docs.sig.network/architecture/sign-bidirectional)
-docs. This README covers only what is Solana-specific.
-
 ## Instructions Reference
 
 ### Developer Instructions
@@ -25,44 +19,157 @@ These are the primary instructions for building applications:
 | [`sign_bidirectional`](https://docs.rs/chain-signatures-solana-program/latest/chain_signatures/chain_signatures/fn.sign_bidirectional.html)       | Cross-chain tx with execution result callback    |
 | [`get_signature_deposit`](https://docs.rs/chain-signatures-solana-program/latest/chain_signatures/chain_signatures/fn.get_signature_deposit.html) | Query the current deposit amount (view function) |
 
-## Sign Bidirectional on Solana
+## Sign Bidirectional Flow
 
-`sign_bidirectional` emits `SignBidirectionalEvent`; the MPC answers with
-`SignatureRespondedEvent` (the transaction signature — the user broadcasts, the MPC
-does not) and, after observing the destination chain, `RespondBidirectionalEvent`
-(the signed execution result). Failed destination transactions are reported with the
-`0xdeadbeef` magic prefix on the output.
-
-See the [Sign Bidirectional Flow](https://docs.sig.network/architecture/sign-bidirectional)
-for the full lifecycle diagram and phase-by-phase description.
-
-## Request ID Generation (Solana encoding)
-
-Each request has a unique ID for tracking. On Solana it uses **packed encoding**:
+The bidirectional flow enables cross-chain transaction execution with verified
+response callbacks:
 
 ```text
-// For sign_bidirectional:
+User                    Solana (Source)         MPC Network        Destination Chain
+  │                        │                         │                    │
+  │ sign_bidirectional()   │                         │                    │
+  ├───────────────────────►│                         │                    │
+  │                        │  SignBidirectionalEvent │                    │
+  │                        ├────────────────────────►│                    │
+  │                        │◄──── respond() ─────────┤                    │
+  │                        │                         │                    │
+  │ Poll SignatureRespondedEvent                     │                    │
+  │◄───────────────────────┤                         │                    │
+  │                        │                         │                    │
+  │ Broadcast signed tx ───┼─────────────────────────┼───────────────────►│
+  │                        │                         │◄── Light client ───┤
+  │                        │◄─ respond_bidirectional()                    │
+  │                        │                         │                    │
+  │ Poll RespondBidirectionalEvent                   │                    │
+  │◄───────────────────────┤                         │                    │
+```
+
+### Phase 1: Sign Request
+
+1. User calls `sign_bidirectional` with serialized unsigned transaction
+2. Program emits `SignBidirectionalEvent`
+3. MPC parses event and generates unique request ID
+
+### Phase 2: Signature Delivery
+
+1. MPC signs the transaction hash
+2. Stores transaction in backlog for observation
+3. Calls `respond`, emitting `SignatureRespondedEvent`
+4. User polls for `SignatureRespondedEvent` to get signature
+
+### Phase 3: User Broadcast
+
+1. User assembles signed transaction (serialized data + signature)
+2. User broadcasts to destination chain
+3. **The MPC does NOT broadcast** - this is the user's responsibility
+
+### Phase 4: Light Client Observation
+
+1. MPC light client monitors destination chain blocks
+2. Detects transaction confirmation by hash
+3. Extracts execution status (success/failure)
+
+### Phase 5: Output Extraction
+
+1. For contract calls: MPC extracts return value
+2. For simple transfers: empty success indicator
+3. Output deserialized using `output_deserialization_schema`
+
+### Phase 6: Respond Bidirectional
+
+1. MPC serializes output using `respond_serialization_schema`
+2. Signs `keccak256(request_id || serialized_output)`
+3. Calls `respond_bidirectional`
+4. Program emits `RespondBidirectionalEvent` for user to poll
+
+## Request ID Generation
+
+Each request has a unique ID for tracking:
+
+```text
+// For sign_bidirectional (packed encoding):
 request_id = keccak256(
     sender || serialized_tx || caip2_id || key_version ||
     path || algo || dest || params
 )
 ```
 
-## Response Signature Verification (Solana specifics)
+## Serialization Schemas
 
-The `respond_bidirectional` response is signed over
-`keccak256(request_id || serialized_output)` using the **fixed Solana response
-derivation path**:
+Cross-chain data encoding uses two schemas:
+
+| Schema                          | Direction         | Purpose                                         |
+| ------------------------------- | ----------------- | ----------------------------------------------- |
+| `output_deserialization_schema` | Destination → MPC | Parse execution result from destination chain   |
+| `respond_serialization_schema`  | MPC → Source      | Serialize response for source chain consumption |
+
+See destination chain guides (e.g., [EVM](https://docs.rs/chain-signatures-solana-program/latest/chain_signatures/evm/index.html)) for format details and examples.
+
+## Error Handling
+
+Failed destination chain transactions are indicated with magic prefix:
+
+```rust
+const MAGIC_ERROR_PREFIX: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+
+// Check if response indicates failure:
+fn is_error(output: &[u8]) -> bool {
+    output.starts_with(&[0xde, 0xad, 0xbe, 0xef])
+}
+```
+
+## Address Derivation
+
+Each user gets a unique destination chain address derived from:
+
+```text
+epsilon = derive_epsilon(sender_pubkey, derivation_path)
+user_pubkey = derive_key(mpc_root_pubkey, epsilon)
+// Address format is chain-specific (see destination chain guides)
+```
+
+## Response Signature Verification
+
+The `respond_bidirectional` response is signed using a **special derivation path**:
 
 ```text
 const RESPONSE_DERIVATION_PATH: &str = "solana response key";
+
+// Response epsilon derivation:
+epsilon = derive_epsilon(key_version, sender_pubkey, "solana response key")
+response_pubkey = derive_key(mpc_root_pubkey, epsilon)
 ```
 
-To verify, recover the public key from the signature with `secp256k1_recover` and
-compare it against the response child key derived from the MPC root with the
-requester's `sender` and the `"solana response key"` path. Why a dedicated response
-key exists — and the generic derivation formula — is covered in the
-[canonical flow docs](https://docs.sig.network/architecture/sign-bidirectional#response-signature-verification).
+The signature is computed over:
+
+```text
+message_hash = keccak256(request_id || serialized_output)
+```
+
+To verify the response signature, clients must:
+
+1. Recover the public key from the signature using `secp256k1_recover`
+2. Derive the expected response public key using the `"solana response key"` path
+3. Compare the recovered public key with the expected response public key
+
+## Security Considerations
+
+### Security Properties
+
+1. **Request ID Uniqueness**: Each request has a unique ID computed from
+   `keccak256(sender || tx || chain_id || ...)` preventing replay attacks
+
+2. **Response Authenticity**: Responses are signed over
+   `keccak256(request_id || serialized_output)` using MPC threshold signatures
+
+3. **Output Verification**: The `output_deserialization_schema` and
+   `respond_serialization_schema` ensure consistent data encoding across chains
+
+4. **Key Isolation**: Each user has isolated keys through unique derivation paths
+   (`epsilon = derive_epsilon(predecessor, path)`)
+
+5. **Light Client Security**: The MPC light client validates destination chain
+   consensus without trusting an RPC provider
 
 ## Destination Chain Guides
 

--- a/signet-program/programs/signet/src/evm.rs
+++ b/signet-program/programs/signet/src/evm.rs
@@ -5,32 +5,12 @@
 //!
 //! ## Overview
 //!
-//! The bidirectional flow enables Solana programs to:
-//! 1. Execute transactions on EVM chains
-//! 2. Receive cryptographically verified execution results back on Solana
-//!
-//! ```text
-//! ┌─────────────────────────────────────────────────────────────────────────┐
-//! │                        SOLANA → EVM FLOW                                │
-//! ├─────────────────────────────────────────────────────────────────────────┤
-//! │                                                                         │
-//! │  Solana Program              MPC Network              EVM Chain         │
-//! │       │                           │                       │             │
-//! │       │ sign_bidirectional()      │                       │             │
-//! │       ├──────────────────────────►│                       │             │
-//! │       │                           │ Sign tx               │             │
-//! │       │◄──── SignatureResponded ──┤                       │             │
-//! │       │                           │                       │             │
-//! │       │              User broadcasts signed tx ──────────►│             │
-//! │       │                           │                       │             │
-//! │       │                           │◄─── Light client ─────┤             │
-//! │       │                           │     observes tx       │             │
-//! │       │                           │                       │             │
-//! │       │◄─ RespondBidirectional ───┤                       │             │
-//! │       │   (execution result)      │                       │             │
-//! │                                                                         │
-//! └─────────────────────────────────────────────────────────────────────────┘
-//! ```
+//! The bidirectional flow lets a Solana program execute a transaction on an EVM chain
+//! and receive the cryptographically verified execution result back on Solana. The
+//! chain-agnostic lifecycle is documented once at
+//! <https://docs.sig.network/architecture/sign-bidirectional>; this module covers the
+//! EVM-destination specifics: transaction encoding, schemas, request ids, and response
+//! verification.
 //!
 //! # Building EVM Transactions
 //!
@@ -324,7 +304,9 @@
 //!
 //! ## Magic Error Prefix
 //!
-//! Failed EVM transactions return output prefixed with `0xDEADBEEF`:
+//! Failed EVM transactions return output prefixed with `0xDEADBEEF` (the protocol-wide
+//! error convention — see
+//! <https://docs.sig.network/architecture/sign-bidirectional#error-handling>):
 //!
 //! ```rust,ignore
 //! const ERROR_PREFIX: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
@@ -336,14 +318,10 @@
 //!
 //! # Response Signature Verification
 //!
-//! The response signature uses a **different derivation path** than the transaction signature:
-//!
-//! | Signature | Derivation Path |
-//! |-----------|-----------------|
-//! | Transaction signature | User's `path` parameter |
-//! | Response signature | `"solana response key"` (hardcoded) |
-//!
-//! This means you must derive the expected response public key using:
+//! The response signature uses the fixed `"solana response key"` derivation path, never
+//! the request's `path` — the response-key model is described in
+//! <https://docs.sig.network/architecture/sign-bidirectional#response-signature-verification>.
+//! Derive the expected response key (and its EVM-style address, if comparing addresses) as:
 //! ```text
 //! epsilon = derive_epsilon(key_version, sender, "solana response key")
 //! response_pubkey = derive_key(mpc_root_pubkey, epsilon)

--- a/signet-program/programs/signet/src/evm.rs
+++ b/signet-program/programs/signet/src/evm.rs
@@ -9,6 +9,8 @@
 //! 1. Execute transactions on EVM chains
 //! 2. Receive cryptographically verified execution results back on Solana
 //!
+//! Chain-agnostic lifecycle reference: <https://docs.sig.network/architecture/sign-bidirectional>
+//!
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────────────────┐
 //! │                        SOLANA → EVM FLOW                                │

--- a/signet-program/programs/signet/src/evm.rs
+++ b/signet-program/programs/signet/src/evm.rs
@@ -5,12 +5,32 @@
 //!
 //! ## Overview
 //!
-//! The bidirectional flow lets a Solana program execute a transaction on an EVM chain
-//! and receive the cryptographically verified execution result back on Solana. The
-//! chain-agnostic lifecycle is documented once at
-//! <https://docs.sig.network/architecture/sign-bidirectional>; this module covers the
-//! EVM-destination specifics: transaction encoding, schemas, request ids, and response
-//! verification.
+//! The bidirectional flow enables Solana programs to:
+//! 1. Execute transactions on EVM chains
+//! 2. Receive cryptographically verified execution results back on Solana
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────┐
+//! │                        SOLANA → EVM FLOW                                │
+//! ├─────────────────────────────────────────────────────────────────────────┤
+//! │                                                                         │
+//! │  Solana Program              MPC Network              EVM Chain         │
+//! │       │                           │                       │             │
+//! │       │ sign_bidirectional()      │                       │             │
+//! │       ├──────────────────────────►│                       │             │
+//! │       │                           │ Sign tx               │             │
+//! │       │◄──── SignatureResponded ──┤                       │             │
+//! │       │                           │                       │             │
+//! │       │              User broadcasts signed tx ──────────►│             │
+//! │       │                           │                       │             │
+//! │       │                           │◄─── Light client ─────┤             │
+//! │       │                           │     observes tx       │             │
+//! │       │                           │                       │             │
+//! │       │◄─ RespondBidirectional ───┤                       │             │
+//! │       │   (execution result)      │                       │             │
+//! │                                                                         │
+//! └─────────────────────────────────────────────────────────────────────────┘
+//! ```
 //!
 //! # Building EVM Transactions
 //!
@@ -304,9 +324,7 @@
 //!
 //! ## Magic Error Prefix
 //!
-//! Failed EVM transactions return output prefixed with `0xDEADBEEF` (the protocol-wide
-//! error convention — see
-//! <https://docs.sig.network/architecture/sign-bidirectional#error-handling>):
+//! Failed EVM transactions return output prefixed with `0xDEADBEEF`:
 //!
 //! ```rust,ignore
 //! const ERROR_PREFIX: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
@@ -318,10 +336,14 @@
 //!
 //! # Response Signature Verification
 //!
-//! The response signature uses the fixed `"solana response key"` derivation path, never
-//! the request's `path` — the response-key model is described in
-//! <https://docs.sig.network/architecture/sign-bidirectional#response-signature-verification>.
-//! Derive the expected response key (and its EVM-style address, if comparing addresses) as:
+//! The response signature uses a **different derivation path** than the transaction signature:
+//!
+//! | Signature | Derivation Path |
+//! |-----------|-----------------|
+//! | Transaction signature | User's `path` parameter |
+//! | Response signature | `"solana response key"` (hardcoded) |
+//!
+//! This means you must derive the expected response public key using:
 //! ```text
 //! epsilon = derive_epsilon(key_version, sender, "solana response key")
 //! response_pubkey = derive_key(mpc_root_pubkey, epsilon)

--- a/signet-program/programs/signet/src/lib.rs
+++ b/signet-program/programs/signet/src/lib.rs
@@ -205,6 +205,8 @@ pub mod chain_signatures {
     /// 3. MPC observes execution via light client
     /// 4. MPC returns execution result via [`respond_bidirectional`]
     ///
+    /// Chain-agnostic lifecycle reference: <https://docs.sig.network/architecture/sign-bidirectional>
+    ///
     /// # Arguments
     ///
     /// * `serialized_transaction` - serialized unsigned transaction for destination chain

--- a/signet-program/programs/signet/src/lib.rs
+++ b/signet-program/programs/signet/src/lib.rs
@@ -199,11 +199,10 @@ pub mod chain_signatures {
 
     /// Initiate a bidirectional cross-chain transaction with execution result callback.
     ///
-    /// This is the primary entry point for cross-chain transactions. The flow:
-    /// 1. User submits unsigned transaction → MPC signs and responds
-    /// 2. User broadcasts to destination chain
-    /// 3. MPC observes execution via light client
-    /// 4. MPC returns execution result via [`respond_bidirectional`]
+    /// This is the primary entry point for cross-chain transactions: the MPC signs and
+    /// answers via [`respond`], the caller broadcasts the signed transaction (the MPC
+    /// does not), and the execution result arrives via [`respond_bidirectional`].
+    /// Full lifecycle: <https://docs.sig.network/architecture/sign-bidirectional>
     ///
     /// # Arguments
     ///

--- a/signet-program/programs/signet/src/lib.rs
+++ b/signet-program/programs/signet/src/lib.rs
@@ -199,10 +199,11 @@ pub mod chain_signatures {
 
     /// Initiate a bidirectional cross-chain transaction with execution result callback.
     ///
-    /// This is the primary entry point for cross-chain transactions: the MPC signs and
-    /// answers via [`respond`], the caller broadcasts the signed transaction (the MPC
-    /// does not), and the execution result arrives via [`respond_bidirectional`].
-    /// Full lifecycle: <https://docs.sig.network/architecture/sign-bidirectional>
+    /// This is the primary entry point for cross-chain transactions. The flow:
+    /// 1. User submits unsigned transaction → MPC signs and responds
+    /// 2. User broadcasts to destination chain
+    /// 3. MPC observes execution via light client
+    /// 4. MPC returns execution result via [`respond_bidirectional`]
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
Adds references from the program docs (README / docs.rs front page, rustdoc) to the canonical chain-agnostic Sign Bidirectional Flow page at https://docs.sig.network/architecture/sign-bidirectional.

Reference links only — the in-depth Solana flow documentation intentionally stays in this repo: each chain's own telling of the flow carries language-specific value. Earlier commits on this branch that slimmed the docs are reverted in-branch; the net diff is 8 added lines.