### PR TITLE
fakenet 0.9.0: signature-only respond-bidirectional (@sig-net 0.14.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ test-ledger/
 # Package manager lock files
 package-lock.json
 pnpm-lock.yaml
+
+# Playwright MCP scratch output (page snapshots, console logs)
+.playwright-mcp/

--- a/fakenet-signer/CLAUDE.md
+++ b/fakenet-signer/CLAUDE.md
@@ -26,7 +26,7 @@ yarn release:patch      # Patch bump, build, publish
 
 ## Architecture
 
-This is a multi-chain signature orchestrator for Solana and Midnight. It listens for signature requests on the source chain (Solana CPI events, or the Midnight signet contract's notification registry), executes transactions on target chains (Ethereum, Bitcoin), monitors completion, and returns results to the source chain. The respond shapes differ: Solana's `RespondBidirectionalEvent` carries the full serialized output on-chain, while Midnight's is hash-only (the ECDSA-signed keccak256 digest of `request_id || serialized_output`), so Midnight clients fetch the raw output themselves (e.g. from the public `/responses/{requestId}` helper API this server exposes) and verify it against the attested digest.
+This is a multi-chain signature orchestrator for Solana and Midnight. It listens for signature requests on the source chain (Solana CPI events, or the Midnight signet contract's notification registry), executes transactions on target chains (Ethereum, Bitcoin), monitors completion, and returns results to the source chain. The respond shapes differ: Solana's `RespondBidirectionalEvent` carries the full serialized output on-chain, while Midnight's is signature-only (the MPC's ECDSA signature over the keccak256 digest of `request_id || serialized_output`, with the digest itself off-chain too), so Midnight clients fetch the raw output themselves (e.g. from the public `/responses/{requestId}` helper API this server exposes), recompute the digest and verify the posted signature over it.
 
 ### Core Flow
 
@@ -34,7 +34,7 @@ This is a multi-chain signature orchestrator for Solana and Midnight. It listens
 2. **ChainSignatureServer**: Main orchestrator that processes signature requests and manages the transaction lifecycle
 3. **Chain Processors**: Sign transactions for target chains (Ethereum: EIP-1559/Legacy, Bitcoin: PSBT)
 4. **Monitors**: Track transaction confirmations with exponential backoff polling
-5. **Bidirectional Handlers**: For sign-and-respond flows that write results back to the source chain (full output to Solana, hash-only attestation to Midnight)
+5. **Bidirectional Handlers**: For sign-and-respond flows that write results back to the source chain (full output to Solana, signature-only attestation to Midnight)
 
 ### Key Components
 
@@ -45,8 +45,8 @@ This is a multi-chain signature orchestrator for Solana and Midnight. It listens
 | EthereumTransactionProcessor | `src/modules/ethereum/`             | Signs EIP-1559 and Legacy transactions                                                               |
 | BitcoinTransactionProcessor  | `src/modules/bitcoin/`              | Builds PSBT signing plans                                                                            |
 | Output serialization         | `src/server/` + `@sig-net/midnight` | Borsh for Solana (ChainSignatureServer), schema-driven packed respond bytes for Midnight (abi-serde) |
-| MidnightMonitor              | `src/modules/`                      | Polls the Midnight signet contract registry for requests, signs and posts hash-only attestations with the sender-scoped response key |
-| ResponsesApi                 | `src/server/`                       | Public `GET /responses/{requestId}` helper API serving each request's raw traced EVM output (a convenience, never an authority: clients digest-match and signature-verify) |
+| MidnightMonitor              | `src/modules/`                      | Polls the Midnight signet contract registry for requests, signs and posts signature-only attestations with the sender-scoped response key |
+| ResponsesApi                 | `src/server/`                       | Public `GET /responses/{requestId}` helper API serving each request's raw traced EVM output (a convenience, never an authority: clients recompute the digest from it and signature-verify) |
 | Bitcoin Adapters             | `src/adapters/`                     | Unified interface for Bitcoin RPC (regtest) and mempool.space API (testnet)                          |
 
 ### Two Workflows

--- a/fakenet-signer/README.md
+++ b/fakenet-signer/README.md
@@ -9,7 +9,7 @@ Multi-chain signature orchestrator that bridges blockchain networks through MPC-
 
 - 🔐 **MPC-Based Key Derivation** - Hierarchical deterministic key derivation from a single root key
 - 🌉 **Multi-Chain Support** - Execute transactions on Ethereum (EIP-1559 & Legacy) and Bitcoin (PSBT), with extensible architecture for more chains
-- 🌙 **Midnight Support**: Polls the signet contract's notification registry, signs requests with per-contract derived keys, and posts hash-only respond-bidirectional attestations
+- 🌙 **Midnight Support**: Polls the signet contract's notification registry, signs requests with per-contract derived keys, and posts signature-only respond-bidirectional attestations
 - ₿ **Bitcoin Adapters** - Unified interface for Bitcoin operations with mempool.space API and Bitcoin Core RPC support
 - 📡 **Event-Driven Architecture** - Subscribes to Solana CPI events for real-time request processing
 - ⚡ **Transaction Monitoring** - Intelligent polling with exponential backoff for transaction confirmation
@@ -375,13 +375,13 @@ The responder needs only the central signet contract's address. It polls that co
 
 For each discovered request the responder rebuilds the unsigned EVM transaction from the on-ledger, contract-controlled parameters, derives the signing key from the MPC root key using the requesting contract's address and the request's 32-byte path (the signet library's v2 epsilon derivation, so clients derive the same expected signer), signs it, and posts the ECDSA signature record on-chain via the signet contract's `respond` circuit. The client polls the contract for the signature and broadcasts the EVM transaction itself.
 
-### Hash-only respond path
+### Signature-only respond path
 
-Unlike Solana, where the full serialized output travels on-chain in the `RespondBidirectionalEvent`, the Midnight respond is hash-only:
+Unlike Solana, where the full serialized output travels on-chain in the `RespondBidirectionalEvent`, the Midnight respond carries the MPC's signature alone:
 
 1. After the EVM transaction confirms, the responder reads the mined call's actual return data via `debug_traceTransaction` (callTracer, top call only: the same RPC method the real MPC uses, which is why `EVM_RPC_URL` must point at a node with the debug namespace enabled). The server probes for support at startup and fails loudly without it, and extraction additionally treats a missing method as an immediate error response, never an endless retry.
 2. The raw return bytes are ABI-decoded per the request's `outputDeserializationSchema` and re-packed per its `respondSerializationSchema` using the schema-driven packed encoding in `@sig-net/midnight` (abi-serde). The result is the exact unpadded byte string clients recompute at claim time. A non-function-call execution (plain transfer) has no output to decode, so schema-typed success defaults are synthesised instead, mirroring the real MPC (string fields become `non_function_call_success`, bool fields become `true`, any other type is an error).
-3. The responder computes the attestation digest `keccak256(requestId || serializedOutput)` and ECDSA-signs it with the per-caller response key (derived from the MPC root key and the requesting contract's address on the fixed "midnight response key" path). The signed digest is posted on-chain via `respondBidirectional`, and the output itself never travels on-chain.
+3. The responder computes the attestation digest `keccak256(requestId || serializedOutput)` and ECDSA-signs it with the per-caller response key (derived from the MPC root key and the requesting contract's address on the fixed "midnight response key" path). The signature is posted on-chain via `respondBidirectional`, and neither the digest nor the output itself travels on-chain.
 4. A failed execution (revert or replacement) is attested the same way over the fixed 5-byte failure output (the `0xDEADBEEF` sentinel plus `0x01`), one width for every respond schema, so client refund circuits can verify it without the receipt.
 
 Clients fetch the raw output off-chain (for example from the `/responses/{requestId}` helper API below), recompute the digest, and verify the posted signature against the response public key their contract pinned at initialisation.
@@ -473,12 +473,12 @@ Runs the Midnight leg end to end:
 
 - Polls the signet contract's notification registry via the GraphQL indexer
 - Resolves notifications to authenticated requests from each requester's ledger
-- Posts signature responses and hash-only respond-bidirectional attestations
+- Posts signature responses and signature-only respond-bidirectional attestations
 - Serialises all contract writes behind a single queue (the private-state store is single-writer)
 
 #### `ResponsesApi`
 
-Public `GET /responses/{requestId}` helper serving each request's raw traced EVM output (a convenience, never an authority: clients digest-match and signature-verify).
+Public `GET /responses/{requestId}` helper serving each request's raw traced EVM output (a convenience, never an authority: clients recompute the digest from it and signature-verify).
 
 #### Output serialization
 
@@ -705,7 +705,7 @@ interface SignatureRequestedEvent {
    - Decode per outputDeserializationSchema, re-pack per respondSerializationSchema
    - Sign the attestation digest keccak256(request_id + serialized_output)
      with the per-caller response key
-   - Post the hash-only respondBidirectional record on-chain
+   - Post the signature-only respondBidirectional record on-chain
 7. On error:
    - Attest the fixed 5-byte failure output (0xDEADBEEF + 0x01) the same way
 ```

--- a/fakenet-signer/package.json
+++ b/fakenet-signer/package.json
@@ -89,8 +89,8 @@
     "tiny-secp256k1": "^2.2.3",
     "tsx": "^4.19.2",
     "zod": "^4.1.11",
-    "@sig-net/midnight": "0.13.0",
-    "@sig-net/midnight-contract": "0.13.0"
+    "@sig-net/midnight": "0.14.0",
+    "@sig-net/midnight-contract": "0.14.0"
   },
   "devDependencies": {
     "tsdown": "^0.15.6"

--- a/fakenet-signer/src/modules/MidnightMonitor.ts
+++ b/fakenet-signer/src/modules/MidnightMonitor.ts
@@ -701,7 +701,7 @@ export class MidnightMonitor {
 
     // The attestation commits to the output AS IS, at its exact unpadded
     // length: no padding and no fixed field width (the event carries only
-    // the digest, the output itself travels off chain).
+    // the signature, the output itself travels off chain).
     const serializedOutput = evmReturnData;
 
     // ECDSA-sign the attestation digest keccak256(requestId || output) with
@@ -715,10 +715,9 @@ export class MidnightMonitor {
     );
     const sig = signAttestationDigest(attestationDigest, responseSecretKey);
     const signature = ecdsaSignatureToMpcSignature(sig);
-    const respondBidirectionalEvent: RespondBidirectionalEvent = {
-      attestationDigest,
-      signature,
-    };
+    // The event carries the signature alone: the digest is recomputed from
+    // the output by whoever verifies, so it never goes on-chain.
+    const respondBidirectionalEvent: RespondBidirectionalEvent = { signature };
 
     const response: SignedResponse = {
       requestId: requestIdHex,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,28 +1508,28 @@
     "@noble/curves" "~1.9.2"
     "@noble/hashes" "~1.8.0"
 
-"@sig-net/midnight-contract@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.13.0.tgz#96bcc78a473d9f9e12ba94c9762f843a67215227"
-  integrity sha512-4QkNxmUXbJF559xeXMOXrif5X8lzTGmdKlerQboEblLZbfXqSEsW7ZytvPbv7CJtqM7nIOCVPNNzgQ0z+29+ZA==
+"@sig-net/midnight-contract@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.14.0.tgz#9f47ab4f10f41e6a99807702e1af1c816cc9c7a3"
+  integrity sha512-90jQzTDd90SIU0IMjPtZHQar8oQaIKN9nFZQJ8L4Jtm/E+UCDlNli6htGvCw26JTZp1FFJVzHDEp6IJ0+CtuVQ==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js" "5.0.0-beta.4"
 
-"@sig-net/midnight-serde@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.13.0.tgz#e97ae7d2c035ee3b17f5b39b25afb5afee993592"
-  integrity sha512-9GiP+7upZnxj/+nLAJZG738Lar9z+HGkrKJFxG5uQracT1B1na8j/ZND0aHb4luLaB+Ln9x+qlc8NA/wnDC+Tg==
+"@sig-net/midnight-serde@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.14.0.tgz#e809c7fc1ba6cacc9a5b47a28dfa859ac87fb8fe"
+  integrity sha512-5B/j5qexy5wNikub8toxoBx6uWjz5/A1Dy/VydEM+Vg4mBjBz/nBtq/0DhBPFBR+rPPvUqS1bi7hT6h4AkEx5A==
 
-"@sig-net/midnight@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.13.0.tgz#bff65342d254a35c23e203c20b72ad4eaa68d3c3"
-  integrity sha512-XVIQUnYyBdfq36Nudk97rzppv5h/uZ+33p8KnE6KYtV61cfP1hE6t5ym8DJike4nsxiaZ/Jc9PJJZY3DopsNbg==
+"@sig-net/midnight@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.14.0.tgz#95f1c97f8047eafca6b945e77c3ff111bb7d20d9"
+  integrity sha512-PrWeBr0Kt1hmWFC/jYH449Obb7rxiTI4VefY4kRC/FPYo7lfLOYqAq+MhV35+qYYB1IfYeMUrCM0FcpfJLL7oQ==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js-types" "5.0.0-beta.4"
     "@noble/curves" "^2.2.0"
-    "@sig-net/midnight-serde" "^0.13.0"
+    "@sig-net/midnight-serde" "^0.14.0"
     ethers "^6.17.0"
 
 "@solana/buffer-layout@^4.0.1":


### PR DESCRIPTION
## What changes

The `RespondBidirectionalEvent` the responder posts to Midnight now carries the MPC's ECDSA signature alone. The attestation digest `keccak256(requestId || serializedOutput)` is still what gets signed — it is simply recomputed by whoever verifies, so it never goes on chain:

```ts
const respondBidirectionalEvent: RespondBidirectionalEvent = { signature };
```

`SignedResponse.attestationDigest` stays: that is the helper API's report of what was signed, not part of the event.

Docs lose the now-wrong "hash-only" framing for "signature-only", in both `README.md` and `CLAUDE.md`.

## Release

Exact pins bumped `0.13.0` → **`0.14.0`** (`@sig-net/midnight`, `@sig-net/midnight-contract`). Unlike the 0.13.0 bump, **the wire protocol did change**: the struct lost a field and the verify circuit lost its digest-equality check, so this image pairs only with the 0.14.0 contracts. Tagged `fakenet-v0.9.0` → `ghcr.io/sig-net/fakenet:0.9.0`.

## Verification

`yarn build` and `yarn lint` green against the published 0.14.0 packages.

Beyond that, this responder — run locally against a local protocol checkout — is what drove both downstream suites to green:

- **sig-net/midnight-integration**: 31/31, both flow files, fresh chain
- **sig-net/midnight-examples** (erc20-vault): 60/60, all six specs

Both attestation branches were exercised on live data: the traced success payload and the fixed 5-byte failure output, each selected by signature alone and then proved in-circuit by the client contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
