### PR TITLE
fakenet 0.10.0: notifications carry the ledger-tree path (@sig-net 0.15.0)

### DIFF
--- a/fakenet-signer/package.json
+++ b/fakenet-signer/package.json
@@ -89,8 +89,8 @@
     "tiny-secp256k1": "^2.2.3",
     "tsx": "^4.19.2",
     "zod": "^4.1.11",
-    "@sig-net/midnight": "0.14.0",
-    "@sig-net/midnight-contract": "0.14.0"
+    "@sig-net/midnight": "0.15.0",
+    "@sig-net/midnight-contract": "0.15.0"
   },
   "devDependencies": {
     "tsdown": "^0.15.6"

--- a/fakenet-signer/src/modules/MidnightMonitor.ts
+++ b/fakenet-signer/src/modules/MidnightMonitor.ts
@@ -2,10 +2,12 @@
  * MidnightMonitor - Generic signet monitor for any Midnight contract.
  *
  * The MPC needs ONLY the signet contract address. Requester contracts are
- * discovered through the signet registry, and each notification names the
- * ledger field position of the caller's SignBidirectionalEventMap, so no
- * compiled caller contract, ZK keys or contract-info.json are needed to
- * READ state (posting responses uses the published signet contract package).
+ * discovered through the signet registry, and each notification carries the
+ * resolved ledger-tree path (requestsPathDepth + requestsPath) of the
+ * caller's SignBidirectionalEventMap, so no compiled caller contract, ZK
+ * keys or contract-info.json are needed to READ state: the feed follows the
+ * path through raw contract state node for node (posting responses uses the
+ * signet contract package).
  *
  * Flow:
  * 1. Polls the signet contract's notification registry via the Midnight

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,28 +1508,28 @@
     "@noble/curves" "~1.9.2"
     "@noble/hashes" "~1.8.0"
 
-"@sig-net/midnight-contract@0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.14.0.tgz#9f47ab4f10f41e6a99807702e1af1c816cc9c7a3"
-  integrity sha512-90jQzTDd90SIU0IMjPtZHQar8oQaIKN9nFZQJ8L4Jtm/E+UCDlNli6htGvCw26JTZp1FFJVzHDEp6IJ0+CtuVQ==
+"@sig-net/midnight-contract@0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.15.0.tgz#025025a72b9ad1cf8e1f94f607c2e3707a24f043"
+  integrity sha512-Og5cYqzVg1VvnYFu4eJtnJQ259hMBneHTyDnQpOVoWMD9eabkDKwDqdvV2EIosHszSZ4KhsWNJsBcP1o3Vc2oQ==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js" "5.0.0-beta.4"
 
-"@sig-net/midnight-serde@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.14.0.tgz#e809c7fc1ba6cacc9a5b47a28dfa859ac87fb8fe"
-  integrity sha512-5B/j5qexy5wNikub8toxoBx6uWjz5/A1Dy/VydEM+Vg4mBjBz/nBtq/0DhBPFBR+rPPvUqS1bi7hT6h4AkEx5A==
+"@sig-net/midnight-serde@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.15.0.tgz#1ee23e459ca834c937d40405a7c11f5ffbde3150"
+  integrity sha512-m2A5WVisejTC9Dvc0fIZK92bnIVihQzuitSTeCt2omPDVthYnJu2HO3zB8LK3LkYNRLnrXkABi9+pQ3e9/i5IA==
 
-"@sig-net/midnight@0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.14.0.tgz#95f1c97f8047eafca6b945e77c3ff111bb7d20d9"
-  integrity sha512-PrWeBr0Kt1hmWFC/jYH449Obb7rxiTI4VefY4kRC/FPYo7lfLOYqAq+MhV35+qYYB1IfYeMUrCM0FcpfJLL7oQ==
+"@sig-net/midnight@0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.15.0.tgz#a5cb8fa4a7a7f50462a0dacc0ac106bc74f3267a"
+  integrity sha512-hlHyw0faBtXjsnSbaEBLLt5Ug9IzPJ5ALwWDOtD/gBnJg2K1jJPn7r+bY0W3M8X3KpH2alWYlL8KVe0liIjI9Q==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js-types" "5.0.0-beta.4"
     "@noble/curves" "^2.2.0"
-    "@sig-net/midnight-serde" "^0.14.0"
+    "@sig-net/midnight-serde" "^0.15.0"
     ethers "^6.17.0"
 
 "@solana/buffer-layout@^4.0.1":


### PR DESCRIPTION
## What

Moves the fakenet responder onto the `@sig-net` 0.15.0 matched set, in which the Midnight signet V1 notification payload carries the resolved ledger-tree path of the caller's request map (`requestsPathDepth` + up to 4 `requestsPath` indices) instead of a single field index.

- `@sig-net/midnight` and `@sig-net/midnight-contract` exact pins: 0.14.0 → 0.15.0
- `MidnightMonitor` header updated to describe the path-based discovery contract (the path walk itself lives in `@sig-net/midnight`'s request feed, so no responder code changes)

## Why

Past 15 ledger fields, compactc packs a contract's public state into a chunk tree, so a flat field index cannot address every contract's request map. The 0.15.0 notification carries the resolved path (read from the caller's compiled `contract-info.json`), and the feed follows it through raw contract state node for node. Chunked (>15 field) callers can now integrate.

## Testing

- `yarn tsc --noEmit` green
- Verified against sig-net/midnight-integration's full integration suite (4 files, 31 tests) twice: once with the workspace packages yarn-linked into this responder, then again with this branch's published 0.15.0 pins, each covering three full sign → broadcast → attest → in-circuit-verify round trips (including a caller with two request maps at different fields)
- Released as `fakenet-v0.10.0` (image `ghcr.io/sig-net/fakenet:0.10.0`), which midnight-integration's compose stack now pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)