### PR TITLE
fakenet: carry the midnight request feed and adopt @sig-net 0.20.0-rc.1

### DIFF
--- a/fakenet-signer/package.json
+++ b/fakenet-signer/package.json
@@ -89,8 +89,8 @@
     "tiny-secp256k1": "^2.2.3",
     "tsx": "^4.19.2",
     "zod": "^4.1.11",
-    "@sig-net/midnight": "0.19.0",
-    "@sig-net/midnight-contract": "0.19.0"
+    "@sig-net/midnight": "0.20.0-rc.1",
+    "@sig-net/midnight-contract": "0.20.0-rc.1"
   },
   "devDependencies": {
     "tsdown": "^0.15.6"

--- a/fakenet-signer/package.json
+++ b/fakenet-signer/package.json
@@ -89,8 +89,8 @@
     "tiny-secp256k1": "^2.2.3",
     "tsx": "^4.19.2",
     "zod": "^4.1.11",
-    "@sig-net/midnight": "0.14.0",
-    "@sig-net/midnight-contract": "0.14.0"
+    "@sig-net/midnight": "0.15.0",
+    "@sig-net/midnight-contract": "0.15.0"
   },
   "devDependencies": {
     "tsdown": "^0.15.6"

--- a/fakenet-signer/src/modules/MidnightMonitor.ts
+++ b/fakenet-signer/src/modules/MidnightMonitor.ts
@@ -24,15 +24,10 @@ import type { SigningRequest } from './midnight/signet-request-types';
 
 import {
   bytesToHex,
-  calculateSignetAttestationDigest,
   deriveMidnightResponseSecretKey,
-  ecdsaSignatureToMpcSignature,
   formatSecp256k1PublicKey,
-  secp256k1PublicKeyOf,
-  signAttestationDigest,
   signetEventSourceFromPublicDataProvider,
   SignetRequestFeed,
-  signatureToSignatureRespondedEvent,
   signBidirectionalEventToUnsignedEvmTransaction,
   MPCDestination,
   MPCSignatureAlgorithm,
@@ -42,6 +37,15 @@ import {
   type SignatureRespondedEvent,
   type RespondBidirectionalEvent,
 } from '@sig-net/midnight';
+// The posting-side helpers: the responder is the MPC's test double, so it
+// signs and encodes through the SDK's minting surface.
+import {
+  calculateSignetAttestationDigest,
+  ecdsaSignatureToMpcSignature,
+  secp256k1PublicKeyOf,
+  signAttestationDigest,
+  signatureToSignatureRespondedEvent,
+} from '@sig-net/midnight/testing';
 import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
 import { PublicDataProvider } from '@midnight-ntwrk/midnight-js-types';
 import { setNetworkId } from '@midnight-ntwrk/midnight-js/network-id';
@@ -660,12 +664,14 @@ export class MidnightMonitor {
       : null;
   }
 
+  /**
+   * The derivation-string rendering of a request's `path: Bytes<32>`:
+   * lowercase hex of the FULL 32 bytes, verbatim, no 0x prefix. Mirrors the
+   * real MPC's rendering (sig-net/mpc chain-midnight convert.rs), which
+   * never trims: `0xab..00` and `0xab..` must derive different keys.
+   */
   getPathHex(request: MidnightSigningRequest): string {
     return Buffer.from(request.path).toString('hex');
-  }
-
-  getPath(request: MidnightSigningRequest): string {
-    return Buffer.from(request.path).toString('utf8').replace(/\0/g, '');
   }
 
   static fromServerConfig(config: ServerConfig): MidnightMonitor | null {

--- a/fakenet-signer/src/modules/MidnightMonitor.ts
+++ b/fakenet-signer/src/modules/MidnightMonitor.ts
@@ -25,7 +25,6 @@ import { type ResolvedSignetRequest, SignetRequestFeed } from './midnight/signet
 
 import {
   bytesToHex,
-  deriveMidnightResponseSecretKey,
   formatSecp256k1PublicKey,
   signetEventSourceFromPublicDataProvider,
   signBidirectionalEventToUnsignedEvmTransaction,
@@ -36,10 +35,11 @@ import {
   type SignatureRespondedEvent,
   type RespondBidirectionalEvent,
 } from '@sig-net/midnight';
-// The posting-side helpers: the responder is the MPC's test double, so it
-// signs and encodes through the SDK's minting surface.
+// The secret-taking helpers: the responder is the MPC's test double, so it
+// derives, signs and encodes through the SDK's minting surface.
 import {
   calculateSignetAttestationDigest,
+  deriveMidnightResponseSecretKey,
   ecdsaSignatureToMpcSignature,
   secp256k1PublicKeyOf,
   signAttestationDigest,

--- a/fakenet-signer/src/modules/MidnightMonitor.ts
+++ b/fakenet-signer/src/modules/MidnightMonitor.ts
@@ -21,17 +21,16 @@ import { ethers } from 'ethers';
 import type { ServerConfig } from '../types';
 
 import type { SigningRequest } from './midnight/signet-request-types';
+import { type ResolvedSignetRequest, SignetRequestFeed } from './midnight/signet-request-feed';
 
 import {
   bytesToHex,
   deriveMidnightResponseSecretKey,
   formatSecp256k1PublicKey,
   signetEventSourceFromPublicDataProvider,
-  SignetRequestFeed,
   signBidirectionalEventToUnsignedEvmTransaction,
   MPCDestination,
   MPCSignatureAlgorithm,
-  type ResolvedSignetRequest,
   type RequestIdHex,
   type SignBidirectionalEvent,
   type SignatureRespondedEvent,

--- a/fakenet-signer/src/modules/MidnightMonitor.ts
+++ b/fakenet-signer/src/modules/MidnightMonitor.ts
@@ -2,10 +2,12 @@
  * MidnightMonitor - Generic signet monitor for any Midnight contract.
  *
  * The MPC needs ONLY the signet contract address. Requester contracts are
- * discovered through the signet registry, and each notification names the
- * ledger field position of the caller's SignBidirectionalEventMap, so no
- * compiled caller contract, ZK keys or contract-info.json are needed to
- * READ state (posting responses uses the published signet contract package).
+ * discovered through the signet registry, and each notification carries the
+ * resolved ledger-tree path (requestsPathDepth + requestsPath) of the
+ * caller's SignBidirectionalEventMap, so no compiled caller contract, ZK
+ * keys or contract-info.json are needed to READ state: the feed follows the
+ * path through raw contract state node for node (posting responses uses the
+ * signet contract package).
  *
  * Flow:
  * 1. Polls the signet contract's notification registry via the Midnight

--- a/fakenet-signer/src/modules/midnight/signet-request-feed.ts
+++ b/fakenet-signer/src/modules/midnight/signet-request-feed.ts
@@ -1,0 +1,178 @@
+// The responder's request discovery: poll the central signet contract's
+// emitted SignBidirectionalEvent notifications and read each declared
+// request from the named caller contract's own request map. A notification
+// says only where to look (caller address, requests path, request id): every
+// request served comes from the caller's authenticated ledger. The TS
+// sibling of the real MPC's Rust indexer (sig-net/mpc,
+// chain-signatures/chain-midnight).
+
+import {
+  decodeSignBidirectionalEventNotificationPayload,
+  decodeSignBidirectionalNotification,
+  isSignetEventNamed,
+  lookupSignetRequestAt,
+  type RawContractState,
+  type RequestIdHex,
+  requestIdHex,
+  type SignBidirectionalEvent,
+  SignetEventName,
+  type SignetEventSource,
+  type SignetPublicStateSource,
+} from '@sig-net/midnight';
+
+/**
+ * A request discovered through a notification event and read from the named
+ * caller's own authenticated ledger.
+ */
+export interface ResolvedSignetRequest {
+  /**
+   * The contract whose authenticated state the request was read from. Key
+   * derivation keys off THIS address, never off a notification field.
+   */
+  callerAddress: string;
+  /** The request id the record is stored under in `callerAddress`'s index. */
+  requestId: RequestIdHex;
+  /** The authenticated request record to sign. */
+  request: SignBidirectionalEvent;
+}
+
+/** Everything a {@link SignetRequestFeed} needs. */
+export interface SignetRequestFeedConfig {
+  /** Address of the central signet contract whose notification events to poll. */
+  readonly signetContractAddress: string;
+  /**
+   * Source of raw contract state for the requester ledgers the feed
+   * enumerates. A full `indexerPublicDataProvider` is assignable.
+   */
+  readonly source: SignetPublicStateSource;
+  /**
+   * Source of the signet contract's emitted events (discovery). Adapt a full
+   * provider with `signetEventSourceFromPublicDataProvider`.
+   */
+  readonly eventSource: SignetEventSource;
+}
+
+/**
+ * The event-polling request feed. Reads the signet contract's emitted
+ * notifications and looks each declared request id up in the pointed-at
+ * caller's own request map, yielding each found request once. Dedupes by
+ * request id across its lifetime: call {@link forget} to re-arm a request
+ * whose downstream processing failed.
+ */
+export class SignetRequestFeed {
+  private readonly signetContractAddress: string;
+  private readonly source: SignetPublicStateSource;
+  private readonly eventSource: SignetEventSource;
+
+  // Request ids already yielded. NOT the security boundary (the caller-ledger
+  // read is), just an at-most-once gate so one request is not processed twice.
+  private readonly yielded = new Set<RequestIdHex>();
+
+  /**
+   * @param config - The signet contract, state and event sources.
+   */
+  constructor(config: SignetRequestFeedConfig) {
+    this.signetContractAddress = config.signetContractAddress;
+    this.source = config.source;
+    this.eventSource = config.eventSource;
+  }
+
+  /**
+   * The unique `(callerAddress, requestsPath, requestId)` pointers of the
+   * currently emitted notification events, in a deterministic order. Deduped
+   * by the FULL triple, so a forged notification cannot shadow a genuine
+   * one. Undecodable events are skipped and logged.
+   *
+   * @returns The deduplicated pointers to look up this cycle.
+   */
+  private async notificationPointers(): Promise<
+    { callerAddress: string; requestsPath: number[]; requestId: RequestIdHex }[]
+  > {
+    const events = await this.eventSource.querySignetEvents(this.signetContractAddress);
+    const pointers = new Map<
+      string,
+      { callerAddress: string; requestsPath: number[]; requestId: RequestIdHex }
+    >();
+    for (const event of events) {
+      if (!isSignetEventNamed(event, SignetEventName.SignBidirectionalEvent)) continue;
+      let pointer;
+      try {
+        const post = decodeSignBidirectionalEventNotificationPayload(event.payload);
+        const notification = decodeSignBidirectionalNotification(post.event);
+        pointer = {
+          callerAddress: notification.callerAddress,
+          requestsPath: notification.requestsPath,
+          requestId: requestIdHex(post.requestId),
+        };
+      } catch (error) {
+        console.warn(
+          `SignetRequestFeed: skipping undecodable notification event: ${String(error)}`
+        );
+        continue;
+      }
+      pointers.set(
+        `${pointer.callerAddress}:${pointer.requestsPath.join(',')}:${pointer.requestId}`,
+        pointer
+      );
+    }
+    return [...pointers.values()].sort((a, b) => {
+      const byCaller =
+        a.callerAddress < b.callerAddress ? -1 : a.callerAddress > b.callerAddress ? 1 : 0;
+      if (byCaller !== 0) return byCaller;
+      return a.requestId < b.requestId ? -1 : a.requestId > b.requestId ? 1 : 0;
+    });
+  }
+
+  /**
+   * One-shot: every notified request not already yielded and found by id in
+   * the pointed-at caller's own request map. A pointer that resolves to
+   * nothing yields nothing WITHOUT marking anything, so it is retried next
+   * cycle.
+   *
+   * @returns The newly-discovered authenticated requests this cycle.
+   * @throws {Error} When the event source itself fails (e.g. the indexer is
+   *   unreachable).
+   */
+  async poll(): Promise<ResolvedSignetRequest[]> {
+    const out: ResolvedSignetRequest[] = [];
+    // Per-cycle caller-state cache: null marks a caller whose state could
+    // not be read this cycle (not a contract / transient read error).
+    const states = new Map<string, RawContractState | null>();
+    for (const pointer of await this.notificationPointers()) {
+      if (this.yielded.has(pointer.requestId)) continue;
+      let raw = states.get(pointer.callerAddress);
+      if (raw === undefined) {
+        try {
+          raw = (await this.source.queryContractState(pointer.callerAddress))?.data ?? null;
+        } catch {
+          raw = null;
+        }
+        states.set(pointer.callerAddress, raw);
+      }
+      if (raw === null) {
+        continue; // no state at the named caller: nothing to serve yet
+      }
+      const request = lookupSignetRequestAt(raw, pointer.requestsPath, pointer.requestId);
+      if (request === undefined) {
+        continue; // forged pointer, or the ledger write has not indexed yet
+      }
+      this.yielded.add(pointer.requestId);
+      out.push({
+        callerAddress: pointer.callerAddress,
+        requestId: pointer.requestId,
+        request,
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Re-arm `requestId` for redelivery on the next {@link poll} cycle: call
+   * when downstream processing of a yielded request failed.
+   *
+   * @param requestId - The request id to allow through again.
+   */
+  forget(requestId: RequestIdHex): void {
+    this.yielded.delete(requestId);
+  }
+}

--- a/fakenet-signer/src/server/ChainSignatureServer.ts
+++ b/fakenet-signer/src/server/ChainSignatureServer.ts
@@ -364,12 +364,11 @@ export class ChainSignatureServer {
       this.midnightMonitor.buildSerializedTransaction(request);
 
     // Derive the signing key using the contract's path field as the derivation
-    // path. The path is 32 opaque bytes of the client contract's choosing;
-    // the derivation-string rendering strips the zero padding (getPath).
-    // The epsilon comes from the signet library (the v2 colon-separated
-    // scheme clients derive the expected signer with), so both sides agree
-    // by construction.
-    const pathString = this.midnightMonitor.getPath(request);
+    // path. The path is 32 opaque bytes of the client contract's choosing,
+    // rendered as its verbatim full-width hex (getPathHex). The epsilon
+    // comes from the signet library (the v2 colon-separated scheme clients
+    // derive the expected signer with), so both sides agree by construction.
+    const pathString = this.midnightMonitor.getPathHex(request);
     const epsilon = deriveEpsilon(
       request.predecessor,
       pathString,
@@ -766,7 +765,9 @@ export class ChainSignatureServer {
    * output from the schema alone), so passing anything through would
    * diverge from the bytes the MPC would attest.
    */
-  private midnightDefaultOutput(schemaBytes: Uint8Array): TransactionOutputData {
+  private midnightDefaultOutput(
+    schemaBytes: Uint8Array
+  ): TransactionOutputData {
     const schemaStr = this.borshSchemaString(schemaBytes);
     if (!schemaStr.trim()) {
       throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,28 +1508,28 @@
     "@noble/curves" "~1.9.2"
     "@noble/hashes" "~1.8.0"
 
-"@sig-net/midnight-contract@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.19.0.tgz#1858a299f39c996216cef4e5e881baa70297e363"
-  integrity sha512-efsNgiOHqqRuTWo6kqRF1hycUCRoC3sO8T3jlzm69ZGqjS0aPsR//BnejdQefHHmMx4sMqDCyeFU8rHeLBq5HQ==
+"@sig-net/midnight-contract@0.20.0-rc.1":
+  version "0.20.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.20.0-rc.1.tgz#a5509ee72bff677bd6eb022cc302ad282b762fc7"
+  integrity sha512-WEXQ9vjzDAHUsxSFkh6NBag5TcJx6HpckkYTcBA115UbVPP4ONhoFVUoLE0LBmn51r2SVelXgwgiOJ2kqHW5Yg==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js" "5.0.0-beta.6"
 
-"@sig-net/midnight-serde@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.19.0.tgz#dac937e7a57b918b750f30cba7c3dc998654d3b1"
-  integrity sha512-gbLEIYrQelmtwNQ3+IsEqXm3QSshesCSJokQInG7ZFQzcfEsdadye1j3gwylKBBxTNki8afloA3JXwZpRna1Rg==
+"@sig-net/midnight-serde@^0.20.0-rc.1":
+  version "0.20.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.20.0-rc.1.tgz#67641d8d01ef85790ba9da86e9cf6a74f5fb52eb"
+  integrity sha512-BjjZ0pOhcOm9b14QSe27zoirdwOjnWpVO54HUWtTd9rTWU3ePemA91JVkqsTZ5SyRn6CJJO1+1Tk8LDhsjrF3g==
 
-"@sig-net/midnight@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.19.0.tgz#175ad377df2292e32f7e2b91512978a2d52d1707"
-  integrity sha512-JiAxjuzK1BE2obf9pJwc50Qaz8Tz2/AyrQZwZPoUfj5leKe020duS1q5FWGG0k36zizsZpRHNlShkdOaKgtAmA==
+"@sig-net/midnight@0.20.0-rc.1":
+  version "0.20.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.20.0-rc.1.tgz#4e07c8d9524db0de244a9827d68f66f7ef843ae9"
+  integrity sha512-Y6LOnGfKaqoEeFuTLwpz8TxIUBBu9y9ZzuKgwgWjkDMAVv1EsrAKiOzHu3Ypcbe44V8+MhOdkx6RErta9Hrfig==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js-types" "5.0.0-beta.6"
     "@noble/curves" "^2.2.0"
-    "@sig-net/midnight-serde" "^0.19.0"
+    "@sig-net/midnight-serde" "^0.20.0-rc.1"
     ethers "^6.17.0"
 
 "@solana/buffer-layout@^4.0.1":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,28 +1508,28 @@
     "@noble/curves" "~1.9.2"
     "@noble/hashes" "~1.8.0"
 
-"@sig-net/midnight-contract@0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.14.0.tgz#9f47ab4f10f41e6a99807702e1af1c816cc9c7a3"
-  integrity sha512-90jQzTDd90SIU0IMjPtZHQar8oQaIKN9nFZQJ8L4Jtm/E+UCDlNli6htGvCw26JTZp1FFJVzHDEp6IJ0+CtuVQ==
+"@sig-net/midnight-contract@0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.15.0.tgz#025025a72b9ad1cf8e1f94f607c2e3707a24f043"
+  integrity sha512-Og5cYqzVg1VvnYFu4eJtnJQ259hMBneHTyDnQpOVoWMD9eabkDKwDqdvV2EIosHszSZ4KhsWNJsBcP1o3Vc2oQ==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js" "5.0.0-beta.4"
 
-"@sig-net/midnight-serde@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.14.0.tgz#e809c7fc1ba6cacc9a5b47a28dfa859ac87fb8fe"
-  integrity sha512-5B/j5qexy5wNikub8toxoBx6uWjz5/A1Dy/VydEM+Vg4mBjBz/nBtq/0DhBPFBR+rPPvUqS1bi7hT6h4AkEx5A==
+"@sig-net/midnight-serde@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.15.0.tgz#1ee23e459ca834c937d40405a7c11f5ffbde3150"
+  integrity sha512-m2A5WVisejTC9Dvc0fIZK92bnIVihQzuitSTeCt2omPDVthYnJu2HO3zB8LK3LkYNRLnrXkABi9+pQ3e9/i5IA==
 
-"@sig-net/midnight@0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.14.0.tgz#95f1c97f8047eafca6b945e77c3ff111bb7d20d9"
-  integrity sha512-PrWeBr0Kt1hmWFC/jYH449Obb7rxiTI4VefY4kRC/FPYo7lfLOYqAq+MhV35+qYYB1IfYeMUrCM0FcpfJLL7oQ==
+"@sig-net/midnight@0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.15.0.tgz#a5cb8fa4a7a7f50462a0dacc0ac106bc74f3267a"
+  integrity sha512-hlHyw0faBtXjsnSbaEBLLt5Ug9IzPJ5ALwWDOtD/gBnJg2K1jJPn7r+bY0W3M8X3KpH2alWYlL8KVe0liIjI9Q==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js-types" "5.0.0-beta.4"
     "@noble/curves" "^2.2.0"
-    "@sig-net/midnight-serde" "^0.14.0"
+    "@sig-net/midnight-serde" "^0.15.0"
     ethers "^6.17.0"
 
 "@solana/buffer-layout@^4.0.1":


### PR DESCRIPTION
## What this delivers

- The midnight request feed now lives in the fakenet responder (its only consumer), stripped to what the responder uses: notification-pointer polling, request resolution and a yielded-set. The SDK's copy is gone as of 0.20.0-rc.1.
- deriveMidnightResponseSecretKey imports from @sig-net/midnight/testing, the entry that owns the secret-taking helpers. The responder is the MPC's test double, so it derives, signs and encodes through the SDK's minting surface.
- @sig-net/midnight and @sig-net/midnight-contract pinned at 0.20.0-rc.1.

Released as fakenet-v0.15.0 (ghcr.io/sig-net/fakenet:0.15.0), which the midnight-integration and midnight-examples stacks now run.