### PR TITLE
fakenet: tick guard release and @sig-net 0.21.0-rc.1

### DIFF
--- a/fakenet-signer/package.json
+++ b/fakenet-signer/package.json
@@ -89,8 +89,8 @@
     "tiny-secp256k1": "^2.2.3",
     "tsx": "^4.19.2",
     "zod": "^4.1.11",
-    "@sig-net/midnight": "0.20.0-rc.1",
-    "@sig-net/midnight-contract": "0.20.0-rc.1"
+    "@sig-net/midnight": "0.21.0-rc.1",
+    "@sig-net/midnight-contract": "0.21.0-rc.1"
   },
   "devDependencies": {
     "tsdown": "^0.15.6"

--- a/fakenet-signer/src/modules/MidnightMonitor.ts
+++ b/fakenet-signer/src/modules/MidnightMonitor.ts
@@ -22,6 +22,7 @@ import type { ServerConfig } from '../types';
 
 import type { SigningRequest } from './midnight/signet-request-types';
 import { type ResolvedSignetRequest, SignetRequestFeed } from './midnight/signet-request-feed';
+import { DEFAULT_TICK_GUARD_RELEASE_MS, runTickWithGuardRelease } from './shared/TickGuard';
 
 import {
   bytesToHex,
@@ -217,11 +218,18 @@ export class MidnightMonitor {
     this.pollIntervalId = setInterval(async () => {
       // A tick can outlast the poll interval (wallet sync, contract writes).
       // Overlapping ticks would write concurrently to the single-writer
-      // private-state store and deadlock on its lock (LEVEL_LOCKED).
+      // private-state store and deadlock on its lock (LEVEL_LOCKED). The
+      // guard release bounds the flip side: a tick that hangs on an
+      // un-timeouted await would otherwise hold this flag forever and kill
+      // discovery silently.
       if (this.polling) return;
       this.polling = true;
       try {
-        await this.fetchAndProcessRequests(handlers.onSigningRequest);
+        await runTickWithGuardRelease(
+          'MidnightMonitor poll',
+          DEFAULT_TICK_GUARD_RELEASE_MS,
+          () => this.fetchAndProcessRequests(handlers.onSigningRequest)
+        );
       } catch (error) {
         console.error('MidnightMonitor: Poll error:', error);
       } finally {

--- a/fakenet-signer/src/modules/shared/TickGuard.ts
+++ b/fakenet-signer/src/modules/shared/TickGuard.ts
@@ -1,0 +1,49 @@
+/**
+ * Deadline after which {@link runTickWithGuardRelease} releases a loop's
+ * re-entrancy guard. Matches the signet write timeout: past it the tick is
+ * either wedged or long enough that a fresh discovery pass is worth more
+ * than strict one-at-a-time ticking.
+ */
+export const DEFAULT_TICK_GUARD_RELEASE_MS = 120_000;
+
+/**
+ * Run one loop tick under a guard-release deadline: resolves when `tick`
+ * settles or after `releaseAfterMs`, whichever comes first, so a hung await
+ * inside a tick can never hold its loop's re-entrancy flag forever (the
+ * failure reads as an idle loop: no error, no log, the interval fires and
+ * returns on the flag every time). On a deadline release the tick itself
+ * keeps running and the release is logged, so a hang is visible instead of
+ * silent. Callers must tolerate a fresh tick overlapping the released one:
+ * discovery is idempotent here and every signet write is serialized
+ * independently, and this repo prefers duplicate processing over a missed
+ * event.
+ *
+ * @param label - Name of the tick, printed in the release warning.
+ * @param releaseAfterMs - Deadline after which the guard is released.
+ * @param tick - The tick body to run.
+ * @returns Resolves when the tick settles or the deadline passes.
+ */
+export async function runTickWithGuardRelease(
+  label: string,
+  releaseAfterMs: number,
+  tick: () => Promise<void>
+): Promise<void> {
+  let timeoutId: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      tick(),
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(() => {
+          console.warn(
+            `${label}: tick still running after ${String(
+              releaseAfterMs / 1000
+            )}s — releasing the loop guard (the tick keeps running)`
+          );
+          resolve();
+        }, releaseAfterMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}

--- a/fakenet-signer/src/server/ChainSignatureServer.ts
+++ b/fakenet-signer/src/server/ChainSignatureServer.ts
@@ -16,6 +16,7 @@ import type {
   SignatureResponse,
 } from '../types';
 import { isSignBidirectionalEvent, isSignatureRequestedEvent } from '../types';
+import { DEFAULT_TICK_GUARD_RELEASE_MS, runTickWithGuardRelease } from '../modules/shared/TickGuard';
 import { serverConfigSchema } from '../types';
 import {
   type ChainSignaturesProgram,
@@ -498,7 +499,11 @@ export class ChainSignatureServer {
       if (this.monitoring) return;
       this.monitoring = true;
       try {
-        await this.runTransactionMonitorTick();
+        await runTickWithGuardRelease(
+          'Transaction monitor',
+          DEFAULT_TICK_GUARD_RELEASE_MS,
+          () => this.runTransactionMonitorTick()
+        );
       } catch (error) {
         console.error('Transaction monitor tick error:', error);
       } finally {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,28 +1508,28 @@
     "@noble/curves" "~1.9.2"
     "@noble/hashes" "~1.8.0"
 
-"@sig-net/midnight-contract@0.20.0-rc.1":
-  version "0.20.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.20.0-rc.1.tgz#a5509ee72bff677bd6eb022cc302ad282b762fc7"
-  integrity sha512-WEXQ9vjzDAHUsxSFkh6NBag5TcJx6HpckkYTcBA115UbVPP4ONhoFVUoLE0LBmn51r2SVelXgwgiOJ2kqHW5Yg==
+"@sig-net/midnight-contract@0.21.0-rc.1":
+  version "0.21.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-contract/-/midnight-contract-0.21.0-rc.1.tgz#887e922dcdeebe441d92e859e734cab297cdb1f6"
+  integrity sha512-RfymX9oxnuUycWuFsazROXjIQaroecH7mNJY/2tbb6QjLNixgBjjkaPHayFQNwafrGfkRHy0B2t8xb4wnSZsAw==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js" "5.0.0-beta.6"
 
-"@sig-net/midnight-serde@^0.20.0-rc.1":
-  version "0.20.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.20.0-rc.1.tgz#67641d8d01ef85790ba9da86e9cf6a74f5fb52eb"
-  integrity sha512-BjjZ0pOhcOm9b14QSe27zoirdwOjnWpVO54HUWtTd9rTWU3ePemA91JVkqsTZ5SyRn6CJJO1+1Tk8LDhsjrF3g==
+"@sig-net/midnight-serde@^0.21.0-rc.1":
+  version "0.21.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight-serde/-/midnight-serde-0.21.0-rc.1.tgz#ec626fdbce514d626553be9fcfad35cd61aee2a8"
+  integrity sha512-hzaPE+Gu1YOvvNEUCnAsSuE4le1WZNReOVfrm3n+nxzoFrFdAirRGk0tahEmfgmtWOZ61WlBFjzxBn2jhXq8iw==
 
-"@sig-net/midnight@0.20.0-rc.1":
-  version "0.20.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.20.0-rc.1.tgz#4e07c8d9524db0de244a9827d68f66f7ef843ae9"
-  integrity sha512-Y6LOnGfKaqoEeFuTLwpz8TxIUBBu9y9ZzuKgwgWjkDMAVv1EsrAKiOzHu3Ypcbe44V8+MhOdkx6RErta9Hrfig==
+"@sig-net/midnight@0.21.0-rc.1":
+  version "0.21.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@sig-net/midnight/-/midnight-0.21.0-rc.1.tgz#f29825b936a97e1ee792eb48ed9b079d1f7813f5"
+  integrity sha512-INzegJcW9k3v2S3ll8YWv5xeajQXBvJFN80xzU2z2jQTGkd9D+FQOBDw7ftu5D9kzZbvb+U+2TDpQpBDUizHaA==
   dependencies:
     "@midnight-ntwrk/compact-runtime" "0.18.0-rc.1"
     "@midnight-ntwrk/midnight-js-types" "5.0.0-beta.6"
     "@noble/curves" "^2.2.0"
-    "@sig-net/midnight-serde" "^0.20.0-rc.1"
+    "@sig-net/midnight-serde" "^0.21.0-rc.1"
     ethers "^6.17.0"
 
 "@solana/buffer-layout@^4.0.1":


### PR DESCRIPTION
## Summary

Two responder hardening changes, released as `fakenet-v0.17.0` (`ghcr.io/sig-net/fakenet:0.17.0`).

- **Tick guard release** (7626793): both polling loops (the MidnightMonitor registry poll and the ChainSignatureServer transaction monitor) run each tick through `runTickWithGuardRelease`, which releases the loop's re-entrancy flag after a 120s deadline instead of holding it forever when an await inside a tick hangs. A hung tick reads as an idle loop with no error and no log, and this makes it visible (the release is logged) while the loop keeps discovering. Callers tolerate an overlapping fresh tick: discovery is idempotent and every signet write is serialized independently.
- **SDK 0.21.0-rc.1** (0299c32): `@sig-net/midnight` and `@sig-net/midnight-contract` move to 0.21.0-rc.1, whose signet event read paginates. On the SDK line before it, one un-paged `queryContractEvents` call caps at the indexer's 100-event page, so a responder watching a registry past 100 events silently stops discovering new requests (restarts re-read the same first page and make it worse).

## Test plan

- `fakenet-signer` builds clean against the new SDK.
- The examples repo's erc20-vault e2e suite runs green against a responder carrying these changes (the pagination fix was validated live against a 179-event registry that had starved the unpaginated responder).